### PR TITLE
CI: Upload reports on build or test failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,4 +56,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-reports
-          path: app/build/reports/tests/testSignedDebugUnitTest/
+          path: app/build/reports/tests/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,20 @@ jobs:
         working-directory: ./
         run: ./gradlew build
 
+      - name: Upload Build Failure Reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-failure-reports
+          path: app/build/reports/
+
       - name: Unit Test
         working-directory: ./
         run: ./gradlew test
+
+      - name: Upload Test Reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: app/build/reports/tests/testSignedDebugUnitTest/


### PR DESCRIPTION
I've updated the build workflow to upload artifacts in two scenarios:

1. If the 'Build with Gradle' step fails:
   - I'll upload general reports from `app/build/reports/` as 'build-failure-reports'. These reports might be partial or incomplete depending on when the build failed.

2. If the 'Unit Test' step fails:
   - I'll upload specific Android unit test reports from `app/build/reports/tests/testSignedDebugUnitTest/` as 'test-reports'.

This provides more comprehensive debugging information for both build and test failures.