### PR TITLE
Hide extra features only for new users

### DIFF
--- a/app/src/main/java/com/erdees/foodcostcalc/data/Preferences.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/data/Preferences.kt
@@ -7,8 +7,10 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.erdees.foodcostcalc.ext.dataStore
 import com.erdees.foodcostcalc.utils.Constants
+import com.erdees.foodcostcalc.utils.FeatureVisibilityByInstallDate
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import org.koin.java.KoinJavaComponent.inject
 import timber.log.Timber
 import java.util.Locale
 
@@ -42,6 +44,9 @@ interface Preferences {
 
 class PreferencesImpl(private val context: Context) : Preferences {
 
+    private val featureVisibilityByInstallDate by inject<FeatureVisibilityByInstallDate>(
+        FeatureVisibilityByInstallDate::class.java
+    )
     private val defaultLocale: Locale = Locale.getDefault()
     private val localeDefaultCurrencyCode: String? =
         Currency.getInstance(defaultLocale)?.currencyCode
@@ -121,14 +126,24 @@ class PreferencesImpl(private val context: Context) : Preferences {
     }
 
     override val showHalfProducts: Flow<Boolean> =
-        context.dataStore.data.map { prefs -> prefs[Keys.SHOW_HALF_PRODUCTS] ?: false }
+        context.dataStore.data.map { prefs ->
+            prefs[Keys.SHOW_HALF_PRODUCTS]
+                ?: featureVisibilityByInstallDate.isDefaultVisibleForPreCutoffUser(
+                    false
+                )
+        }
 
     override suspend fun setShowHalfProducts(value: Boolean) {
         context.dataStore.edit { prefs -> prefs[Keys.SHOW_HALF_PRODUCTS] = value }
     }
 
     override val showProductTax: Flow<Boolean> =
-        context.dataStore.data.map { prefs -> prefs[Keys.SHOW_PRODUCT_TAX] ?: false }
+        context.dataStore.data.map { prefs ->
+            prefs[Keys.SHOW_PRODUCT_TAX]
+                ?: featureVisibilityByInstallDate.isDefaultVisibleForPreCutoffUser(
+                    false
+                )
+        }
 
     override suspend fun setShowProductTax(value: Boolean) {
         context.dataStore.edit { prefs -> prefs[Keys.SHOW_PRODUCT_TAX] = value }

--- a/app/src/main/java/com/erdees/foodcostcalc/utils/FeatureVisibilityByInstallDate.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/utils/FeatureVisibilityByInstallDate.kt
@@ -1,0 +1,40 @@
+package com.erdees.foodcostcalc.utils
+
+import java.time.LocalDate
+import java.time.Month
+import java.time.ZoneId
+
+/**
+ * Interface to determine feature visibility based on an install date
+ * relative to a cutoff date.
+ */
+interface FeatureVisibilityByInstallDate {
+    /**
+     * Checks if a feature should be visible by default for a user
+     * who installed the app before a predefined cutoff time.
+     *
+     * @return true if the install time is before the cutoff, false otherwise.
+     */
+    fun isDefaultVisibleForPreCutoffUser(assumeVisibleOnError: Boolean): Boolean
+}
+
+@Suppress("MagicNumber")
+class FeatureVisibilityByInstallDateImpl(
+    private val firstInstallTime: Long?,
+    private val cutOffLocalDate: LocalDate = LocalDate.of(2025, Month.JUNE, 1)
+) : FeatureVisibilityByInstallDate {
+
+    private val featureHiddenByDefaultCutoff: Long by lazy {
+        cutOffLocalDate.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli()
+    }
+
+    override fun isDefaultVisibleForPreCutoffUser(
+        assumeVisibleOnError: Boolean
+    ): Boolean {
+        return if (firstInstallTime == null) {
+            assumeVisibleOnError
+        } else {
+            firstInstallTime < featureHiddenByDefaultCutoff
+        }
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/utils/di/UtilModule.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/utils/di/UtilModule.kt
@@ -1,11 +1,27 @@
 package com.erdees.foodcostcalc.utils.di
 
+import android.content.pm.PackageManager
+import com.erdees.foodcostcalc.utils.FeatureVisibilityByInstallDate
+import com.erdees.foodcostcalc.utils.FeatureVisibilityByInstallDateImpl
 import com.erdees.foodcostcalc.utils.MyDispatchers
 import com.erdees.foodcostcalc.utils.MyDispatchersImpl
 import com.erdees.foodcostcalc.utils.billing.PremiumUtil
+import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
+import timber.log.Timber
 
 val utilModule = module {
     single<PremiumUtil> { PremiumUtil(get()) }
     single<MyDispatchers> { MyDispatchersImpl() }
+    single<FeatureVisibilityByInstallDate> {
+        val firstInstallTime: Long? = try {
+            val packageInfo =
+                androidContext().packageManager.getPackageInfo(androidContext().packageName, 0)
+            packageInfo.firstInstallTime
+        } catch (e: PackageManager.NameNotFoundException) {
+            Timber.e(e, "Could not get package info to determine first install time.")
+            null
+        }
+        FeatureVisibilityByInstallDateImpl(firstInstallTime = firstInstallTime)
+    }
 }

--- a/app/src/test/java/com/erdees/foodcostcalc/utils/FeatureVisibilityByInstallDateImplTest.kt
+++ b/app/src/test/java/com/erdees/foodcostcalc/utils/FeatureVisibilityByInstallDateImplTest.kt
@@ -1,0 +1,130 @@
+package com.erdees.foodcostcalc.utils
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import java.time.LocalDate
+import java.time.Month
+import java.time.ZoneId
+
+class FeatureVisibilityByInstallDateImplTest {
+
+    // Helper to convert date to millis since epoch for consistency in tests
+    private fun getMillis(month: Month, day: Int): Long {
+        return LocalDate
+            .of(2025, month, day)
+            .atStartOfDay(ZoneId.of("UTC"))
+            .toInstant()
+            .toEpochMilli()
+    }
+    private val featureHiddenByDefaultCutoffTimeMs = LocalDate.of(2025, Month.JUNE, 1)
+
+    @Test
+    fun `Pre cutoff install time assumeVisibleOnError true`() {
+        // Given firstInstallTime is before featureHiddenByDefaultCutoff
+        val firstInstallTime = getMillis(Month.MAY, 31)
+        val checker: FeatureVisibilityByInstallDate = FeatureVisibilityByInstallDateImpl(
+            firstInstallTime = firstInstallTime,
+            cutOffLocalDate = featureHiddenByDefaultCutoffTimeMs
+        )
+        // When isDefaultVisibleForPreCutoffUser is called
+        val result = checker.isDefaultVisibleForPreCutoffUser(true)
+        // Then it should return true.
+        result shouldBe true
+    }
+
+    @Test
+    fun `Pre cutoff install time assumeVisibleOnError false`() {
+        // Given firstInstallTime is before featureHiddenByDefaultCutoff
+        val firstInstallTime = getMillis(Month.MAY, 31)
+        val checker: FeatureVisibilityByInstallDate = FeatureVisibilityByInstallDateImpl(
+            firstInstallTime = firstInstallTime,
+            cutOffLocalDate = featureHiddenByDefaultCutoffTimeMs
+        )
+        // When isDefaultVisibleForPreCutoffUser is called
+        val result = checker.isDefaultVisibleForPreCutoffUser(false)
+        // Then it should return true.
+        result shouldBe true
+    }
+
+    @Test
+    fun `Post cutoff install time assumeVisibleOnError true`() {
+        // Given firstInstallTime is before featureHiddenByDefaultCutoff
+        val firstInstallTime = getMillis(Month.JUNE, 10)
+        val checker: FeatureVisibilityByInstallDate = FeatureVisibilityByInstallDateImpl(
+            firstInstallTime = firstInstallTime,
+            cutOffLocalDate = featureHiddenByDefaultCutoffTimeMs
+        )
+        // When isDefaultVisibleForPreCutoffUser is called
+        val result = checker.isDefaultVisibleForPreCutoffUser(true)
+        // Then it should return false.
+        result shouldBe false
+    }
+
+    @Test
+    fun `Post cutoff install time assumeVisibleOnError false`() {
+        // Given firstInstallTime is before featureHiddenByDefaultCutoff
+        val firstInstallTime = getMillis(Month.JUNE, 10)
+        val checker: FeatureVisibilityByInstallDate = FeatureVisibilityByInstallDateImpl(
+            firstInstallTime = firstInstallTime,
+            cutOffLocalDate = featureHiddenByDefaultCutoffTimeMs
+        )
+        // When isDefaultVisibleForPreCutoffUser is called
+        val result = checker.isDefaultVisibleForPreCutoffUser(false)
+        // Then it should return false.
+        result shouldBe false
+    }
+
+    @Test
+    fun `install time null assumeVisibleOnErrortrue`() {
+        // Given firstInstallTime is null
+        val checker: FeatureVisibilityByInstallDate = FeatureVisibilityByInstallDateImpl(
+            firstInstallTime = null,
+            cutOffLocalDate = featureHiddenByDefaultCutoffTimeMs
+        )
+        // When isDefaultVisibleForPreCutoffUser is called
+        val result = checker.isDefaultVisibleForPreCutoffUser(true)
+        // Then it returns assumeVisibleOnError
+        result shouldBe true
+    }
+
+    @Test
+    fun `install time null assumeVisibleOnError false`() {
+        // Given firstInstallTime is null
+        val checker: FeatureVisibilityByInstallDate = FeatureVisibilityByInstallDateImpl(
+            firstInstallTime = null,
+            cutOffLocalDate = featureHiddenByDefaultCutoffTimeMs
+        )
+        // When isDefaultVisibleForPreCutoffUser is called
+        val result = checker.isDefaultVisibleForPreCutoffUser(false)
+        // Then it returns assumeVisibleOnError
+        result shouldBe false
+    }
+
+    @Test
+    fun `firstInstallTime is Long MAX VALUE`() {
+        // Given firstInstallTime is Long MAX VALUE
+        val firstInstallTime = Long.MAX_VALUE
+        val checker: FeatureVisibilityByInstallDate = FeatureVisibilityByInstallDateImpl(
+            firstInstallTime = firstInstallTime,
+            cutOffLocalDate = featureHiddenByDefaultCutoffTimeMs
+        )
+        // When isDefaultVisibleForPreCutoffUser is called
+        val result = checker.isDefaultVisibleForPreCutoffUser(true)
+        // Then it should return false.
+        result shouldBe false
+    }
+
+    @Test
+    fun `firstInstallTime is Long MIN VALUE`() {
+        // Given firstInstallTime is before featureHiddenByDefaultCutoff
+        val firstInstallTime = Long.MIN_VALUE
+        val checker: FeatureVisibilityByInstallDate = FeatureVisibilityByInstallDateImpl(
+            firstInstallTime = firstInstallTime,
+            cutOffLocalDate = featureHiddenByDefaultCutoffTimeMs
+        )
+        // When isDefaultVisibleForPreCutoffUser is called
+        val result = checker.isDefaultVisibleForPreCutoffUser(true)
+        // Then it should return true.
+        result shouldBe true
+    }
+}


### PR DESCRIPTION
Do not hide features by default for users that used app before UX improvements that reduce cognitive load. Hide features by default only for new users.