### PR TITLE
Here's the revised commit message:

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,6 @@ and garlic. We can create our half productModel as Marinated shrimp input all of
 and then re-use it in dishes to calculate food cost . App supports metric and basic US system units.
 Please send suggestions / opinions.
 
-## Screenshots 
-
-<p align="center">
- <img src="https://user-images.githubusercontent.com/70368829/109799505-ccb4cd00-7c24-11eb-8536-9a7d8d8bb20a.png" width="350">
-   <img src="https://user-images.githubusercontent.com/70368829/109799512-cf172700-7c24-11eb-9935-83049ea3832a.png" width="350">
- <img src="https://user-images.githubusercontent.com/70368829/109799511-ce7e9080-7c24-11eb-810f-59c3f688c633.png" width="350">
-  <img src="https://user-images.githubusercontent.com/70368829/109799509-cde5fa00-7c24-11eb-925d-5a4ee887d491.png" width="350">
-</p>
-
-
 ### Design
 App follows Material 3 Design. Icons are sharp with weight of 200, grade 0, and size 24.
 


### PR DESCRIPTION
Remove outdated screenshots from README.md

This commit removes the "Screenshots" section from the README.md file, as the images were outdated.