### PR TITLE
PROJECT STAY: Create Dish Revamp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -159,8 +159,9 @@ dependencies {
     implementation(libs.material)
     implementation(libs.core.ktx)
 
-    // KotlinX coroutines
+    // KotlinX
     implementation(libs.coroutines.android)
+    implementation(libs.kotlinx.immutable.collections)
 
     // Lifecycle
     implementation(libs.lifecycle.viewmodel.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -168,6 +168,7 @@ dependencies {
     // Room
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
+    androidTestImplementation(libs.room.testing)
     ksp(libs.room.compiler)
 
     // Activity KTX

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     tools:ignore="ScopedStorage" />
   <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  <uses-permission android:name="android.permission.VIBRATE" />
 
 
   <application

--- a/app/src/main/java/com/erdees/foodcostcalc/data/db/dao/dish/DishDao.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/data/db/dao/dish/DishDao.kt
@@ -21,7 +21,7 @@ interface DishDao {
     fun getCompleteDish(id: Long): Flow<CompleteDish>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun addDish(dish: DishBase)
+    suspend fun addDish(dish: DishBase): Long
 
     @Update
     suspend fun editDish(dish: DishBase)

--- a/app/src/main/java/com/erdees/foodcostcalc/data/db/dao/product/ProductDao.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/data/db/dao/product/ProductDao.kt
@@ -17,7 +17,7 @@ interface ProductDao {
     fun getProduct(id: Long): Flow<ProductBase>
 
     @Insert(onConflict = OnConflictStrategy.ABORT)
-    suspend fun addProduct(product: ProductBase)
+    suspend fun addProduct(product: ProductBase) : Long
 
     @Update
     suspend fun editProduct(newProduct: ProductBase)

--- a/app/src/main/java/com/erdees/foodcostcalc/data/repository/DishRepository.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/data/repository/DishRepository.kt
@@ -15,7 +15,7 @@ interface DishRepository {
     val dishes: Flow<List<CompleteDish>>
     suspend fun getDish(id: Long): Flow<CompleteDish>
 
-    suspend fun addDish(dish: DishBase)
+    suspend fun addDish(dish: DishBase): Long
     suspend fun deleteDish(dishId: Long)
     suspend fun updateDish(dish: DishBase)
     suspend fun updateDishRecipe(recipeId: Long, dishId: Long)
@@ -35,9 +35,9 @@ class DishRepositoryImpl : DishRepository, KoinComponent {
 
     override suspend fun getDish(id: Long) = dishDao.getCompleteDish(id)
 
-    override suspend fun addDish(dish: DishBase) {
+    override suspend fun addDish(dish: DishBase) =
         dishDao.addDish(dish)
-    }
+
 
     override suspend fun deleteDish(dishId: Long) {
         dishDao.deleteDish(dishId)

--- a/app/src/main/java/com/erdees/foodcostcalc/data/repository/ProductRepository.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/data/repository/ProductRepository.kt
@@ -11,7 +11,7 @@ import org.koin.core.component.inject
 interface ProductRepository {
   val products: Flow<List<ProductBase>>
   suspend fun getProduct(id: Long) : Flow<ProductBase>
-  suspend fun addProduct(product: ProductBase)
+  suspend fun addProduct(product: ProductBase): Long
   suspend fun addProductDish(productDish: ProductDish)
   suspend fun editProduct(newProduct: ProductBase)
   suspend fun deleteProduct(id: Long)

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/mapper/Mapper.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/mapper/Mapper.kt
@@ -22,6 +22,7 @@ import com.erdees.foodcostcalc.domain.model.dish.DishDomain
 import com.erdees.foodcostcalc.domain.model.halfProduct.HalfProductDomain
 import com.erdees.foodcostcalc.domain.model.halfProduct.UsedHalfProductDomain
 import com.erdees.foodcostcalc.domain.model.product.EditableProductDomain
+import com.erdees.foodcostcalc.domain.model.product.ProductAddedToDish
 import com.erdees.foodcostcalc.domain.model.product.ProductDomain
 import com.erdees.foodcostcalc.domain.model.product.UsedProductDomain
 import com.erdees.foodcostcalc.domain.model.recipe.EditableRecipe
@@ -277,4 +278,15 @@ object Mapper {
         )
     }
 
+    fun ProductAddedToDish.toProductDish(dishId: Long): ProductDish {
+        return ProductDish(
+            productId = item.id,
+            dishId = dishId,
+            quantity = quantity,
+            quantityUnit = quantityUnit,
+            productDishId = AUTO_GENERATED_ID,
+        )
+    }
+
+    private const val AUTO_GENERATED_ID = 0L
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/ItemUsageEntry.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/ItemUsageEntry.kt
@@ -1,0 +1,32 @@
+package com.erdees.foodcostcalc.domain.model
+
+import android.icu.util.Currency
+import com.erdees.foodcostcalc.utils.Utils
+import java.text.DecimalFormat
+
+/**
+ * Represents the details of how a specific item is being used,
+ * including its quantity and calculated price for that usage,
+ * before it's formally persisted with its own identity.
+ */
+interface ItemUsageEntry {
+    val item: Item
+    val quantity: Double
+    val quantityUnit: String
+    val foodCost: Double
+
+    fun formattedTotalPricePerServing(amountOfServings: Double, currency: Currency?): String =
+        Utils.formatPrice(foodCost * amountOfServings, currency)
+
+    fun formatQuantityForTargetServing(servings: Double): String =
+        DecimalFormat("#.##").format(quantity * servings)
+
+    fun formatQuantityForTargetServing(
+        baseQuantity: Double,
+        targetQuantity: Double
+    ): String {
+        val percentageOfBaseQuantity = targetQuantity * 100 / baseQuantity
+        val adjustedQuantity = quantity * (percentageOfBaseQuantity / 100)
+        return DecimalFormat("#.##").format(adjustedQuantity)
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/ItemUsageEntry.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/ItemUsageEntry.kt
@@ -21,6 +21,7 @@ interface ItemUsageEntry {
     fun formatQuantityForTargetServing(servings: Double): String =
         DecimalFormat("#.##").format(quantity * servings)
 
+    @Suppress("MagicNumber")
     fun formatQuantityForTargetServing(
         baseQuantity: Double,
         targetQuantity: Double

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/UsedItem.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/UsedItem.kt
@@ -1,30 +1,9 @@
 package com.erdees.foodcostcalc.domain.model
 
-import android.icu.util.Currency
-import com.erdees.foodcostcalc.utils.Utils
-import java.text.DecimalFormat
-
-interface UsedItem {
+/**
+ * Represents a [ItemUsageEntry] that has been persisted and has an identity.
+ */
+interface UsedItem : ItemUsageEntry {
     val id: Long
     val ownerId: Long
-    val item: Item
-    val quantity: Double
-    val quantityUnit: String
-
-    val totalPrice: Double
-
-    fun formattedTotalPricePerServing(amountOfServings: Double, currency: Currency?): String =
-        Utils.formatPrice(totalPrice * amountOfServings, currency)
-
-    fun formatQuantityForTargetServing(servings: Double): String =
-        DecimalFormat("#.##").format(quantity * servings)
-
-    fun formatQuantityForTargetServing(
-        baseQuantity: Double,
-        targetQuantity: Double
-    ): String {
-        val percentageOfBaseQuantity = targetQuantity * 100 / baseQuantity
-        val adjustedQuantity = quantity * (percentageOfBaseQuantity / 100)
-        return DecimalFormat("#.##").format(adjustedQuantity)
-    }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishDomain.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishDomain.kt
@@ -74,11 +74,6 @@ data class DishDomain(
         var bestAttemptDish = this.copy(marginPercent = initialRawMarginPercent)
         var closestDifference = abs(bestAttemptDish.totalPrice - targetTotalPrice)
 
-        if (closestDifference <= TOLERANCE) {
-            Timber.d("Initial raw margin is sufficient: targetTotalPrice=$targetTotalPrice, result.totalPrice=${bestAttemptDish.totalPrice}, margin=${bestAttemptDish.marginPercent}")
-            return bestAttemptDish
-        }
-
         repeat(MAX_ITERATIONS) {
             val roundedMarginPercent = Utils.formatDouble(currentPrecision, initialRawMarginPercent)
             val candidateDish = this.copy(marginPercent = roundedMarginPercent)

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishDomain.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishDomain.kt
@@ -23,11 +23,11 @@ data class DishDomain(
     val recipe: RecipeDomain?,
 ) : Item {
     val foodCost: Double = products.sumOf {
-        it.totalPrice.also { totalPrice ->
+        it.foodCost.also { totalPrice ->
             Timber.v("Product: ${it}, quantity : ${it.quantity}, totalPrice: $totalPrice")
         }
     } + halfProducts.sumOf {
-        it.totalPrice.also { totalPrice ->
+        it.foodCost.also { totalPrice ->
             Timber.v("Half product: ${it}, quantity : ${it.quantity}, totalPrice: $totalPrice")
         }
     }
@@ -37,11 +37,8 @@ data class DishDomain(
     }
 
     val totalPrice: Double
-        get() {
-            val priceWithMargin = foodCost * marginPercent / 100
-            val amountOfTax = priceWithMargin * taxPercent / 100
-            return priceWithMargin + amountOfTax
-        }
+        get() = Utils.getDishFinalPrice(foodCost, marginPercent, taxPercent)
+
 
     private fun finalPricePerServing(amountOfServings: Int): Double {
         return totalPrice * amountOfServings

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/halfProduct/HalfProductDomain.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/halfProduct/HalfProductDomain.kt
@@ -16,7 +16,7 @@ data class HalfProductDomain(
     val halfProductUnit: String,
     val products: List<UsedProductDomain>
 ) : Item {
-    private val singleRecipePrice = products.sumOf { it.totalPrice }
+    private val singleRecipePrice = products.sumOf { it.foodCost }
 
     val totalQuantity =
         if (halfProductUnit == "per piece") 1.0

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/halfProduct/UsedHalfProductDomain.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/halfProduct/UsedHalfProductDomain.kt
@@ -15,7 +15,7 @@ data class UsedHalfProductDomain(
     override val quantityUnit: String
 ) : UsedItem {
 
-    override val totalPrice = UnitsUtils.calculatePrice(
+    override val foodCost = UnitsUtils.calculatePrice(
         item.pricePerUnit,
         quantity,
         item.halfProductUnit,

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/product/ProductAddedToDish.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/product/ProductAddedToDish.kt
@@ -1,0 +1,24 @@
+package com.erdees.foodcostcalc.domain.model.product
+
+import androidx.annotation.Keep
+import com.erdees.foodcostcalc.domain.model.ItemUsageEntry
+import com.erdees.foodcostcalc.utils.UnitsUtils.calculatePrice
+import kotlinx.serialization.Serializable
+
+/**
+ * Can be used in dish or half-product
+ * */
+@Keep
+@Serializable
+data class ProductAddedToDish(
+    override val item: ProductDomain,
+    override val quantity: Double,
+    override val quantityUnit: String,
+) : ItemUsageEntry {
+    override val foodCost = calculatePrice(
+        item.priceAfterWasteAndTax,
+        quantity,
+        item.unit,
+        quantityUnit,
+    )
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/product/UsedProductDomain.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/product/UsedProductDomain.kt
@@ -20,7 +20,7 @@ data class UsedProductDomain(
     override val quantityUnit: String,
     val weightPiece: Double?
 ) : UsedItem {
-    override val totalPrice = calculatePrice(
+    override val foodCost = calculatePrice(
         item.priceAfterWasteAndTax,
         quantity,
         item.unit,
@@ -33,7 +33,7 @@ data class UsedProductDomain(
         currency: Currency?
     ): String {
         val percentageOfBaseQuantity = targetQuantity * 100 / baseQuantity
-        val adjustedPrice = totalPrice * (percentageOfBaseQuantity / 100)
+        val adjustedPrice = foodCost * (percentageOfBaseQuantity / 100)
         return Utils.formatPrice(adjustedPrice, currency)
     }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ext/Context.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ext/Context.kt
@@ -1,7 +1,12 @@
 package com.erdees.foodcostcalc.ext
 
 import android.content.Context
+import android.content.Context.VIBRATOR_SERVICE
 import android.content.ContextWrapper
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
 import androidx.activity.ComponentActivity
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.SharedPreferencesMigration
@@ -20,3 +25,15 @@ val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
         listOf(SharedPreferencesMigration(context, "settings"))
     }
 )
+
+fun Context.vibrateForConfirmation() {
+    val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        val vibratorManager =
+            getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+        vibratorManager.defaultVibrator
+    } else {
+        @Suppress("DEPRECATION")
+        getSystemService(VIBRATOR_SERVICE) as Vibrator
+    }
+    vibrator.vibrate(VibrationEffect.createOneShot(200, VibrationEffect.DEFAULT_AMPLITUDE))
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ext/Context.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ext/Context.kt
@@ -35,5 +35,7 @@ fun Context.vibrateForConfirmation() {
         @Suppress("DEPRECATION")
         getSystemService(VIBRATOR_SERVICE) as Vibrator
     }
-    vibrator.vibrate(VibrationEffect.createOneShot(200, VibrationEffect.DEFAULT_AMPLITUDE))
+    vibrator.vibrate(VibrationEffect.createOneShot(ShortVibration, VibrationEffect.DEFAULT_AMPLITUDE))
 }
+
+private const val ShortVibration = 200L

--- a/app/src/main/java/com/erdees/foodcostcalc/ext/DishDomain.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ext/DishDomain.kt
@@ -18,7 +18,7 @@ fun DishDomain.toShareableText(
     products.forEach { product ->
         builder.append("${product.item.name} ${product.quantity * portions} ${product.quantityUnit}.")
         if (showIngredientPrices) {
-            builder.append(" ${product.totalPrice}.")
+            builder.append(" ${product.foodCost}.")
         }
         builder.appendLine()
     }
@@ -26,7 +26,7 @@ fun DishDomain.toShareableText(
     halfProducts.forEach { halfProduct ->
         builder.append("${halfProduct.item.name} ${halfProduct.quantity * portions} ${halfProduct.quantityUnit}.")
         if (showIngredientPrices) {
-            builder.append(" ${halfProduct.totalPrice}.")
+            builder.append(" ${halfProduct.foodCost}.")
         }
         builder.appendLine()
     }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/composables/Ingredients.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/composables/Ingredients.kt
@@ -43,20 +43,20 @@ fun Ingredients(
     Column(
         modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        (products + halfProducts).forEachIndexed { index, it ->
+        (products + halfProducts).forEachIndexed { index, itemUsageEntry ->
             val needsExtraSpace = index != 0 && spacious
             IngredientRow(
                 modifier = Modifier.padding(
                     bottom = if (spacious) 8.dp else 4.dp,
                     top = if (needsExtraSpace) 8.dp else 0.dp
                 ),
-                description = it.item.name,
+                description = itemUsageEntry.item.name,
                 quantity = stringResource(
                     R.string.formatted_quantity,
-                    it.formatQuantityForTargetServing(servings),
-                    UnitsUtils.getUnitAbbreviation(it.quantityUnit)
+                    itemUsageEntry.formatQuantityForTargetServing(servings),
+                    UnitsUtils.getUnitAbbreviation(itemUsageEntry.quantityUnit)
                 ),
-                price = it.formattedTotalPricePerServing(servings, currency),
+                price = itemUsageEntry.formattedTotalPricePerServing(servings, currency),
                 showPrice = showPrices
             )
             if (spacious) FCCThickSecondaryHorizontalDivider()

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/composables/Ingredients.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/composables/Ingredients.kt
@@ -12,8 +12,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.erdees.foodcostcalc.R
+import com.erdees.foodcostcalc.domain.model.ItemUsageEntry
 import com.erdees.foodcostcalc.domain.model.dish.DishDomain
 import com.erdees.foodcostcalc.ui.composables.dividers.FCCSecondaryHorizontalDivider
+import com.erdees.foodcostcalc.ui.composables.dividers.FCCThickSecondaryHorizontalDivider
 import com.erdees.foodcostcalc.ui.composables.rows.IngredientRow
 import com.erdees.foodcostcalc.utils.UnitsUtils
 
@@ -25,12 +27,29 @@ fun Ingredients(
     modifier: Modifier = Modifier,
     showPrices: Boolean = true
 ) {
+    Ingredients(dishDomain.products, dishDomain.halfProducts, servings, currency, modifier, showPrices)
+}
+
+@Composable
+fun Ingredients(
+    products: List<ItemUsageEntry>,
+    halfProducts: List<ItemUsageEntry>,
+    servings: Double,
+    currency: Currency?,
+    modifier: Modifier = Modifier,
+    showPrices: Boolean = true,
+    spacious: Boolean = false
+) {
     Column(
         modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        (dishDomain.products + dishDomain.halfProducts).forEach {
+        (products + halfProducts).forEachIndexed { index, it ->
+            val needsExtraSpace = index != 0 && spacious
             IngredientRow(
-                modifier = Modifier.padding(bottom = 4.dp),
+                modifier = Modifier.padding(
+                    bottom = if (spacious) 8.dp else 4.dp,
+                    top = if (needsExtraSpace) 8.dp else 0.dp
+                ),
                 description = it.item.name,
                 quantity = stringResource(
                     R.string.formatted_quantity,
@@ -40,7 +59,8 @@ fun Ingredients(
                 price = it.formattedTotalPricePerServing(servings, currency),
                 showPrice = showPrices
             )
-            FCCSecondaryHorizontalDivider()
+            if (spacious) FCCThickSecondaryHorizontalDivider()
+            else FCCSecondaryHorizontalDivider()
         }
         Spacer(modifier = Modifier.height(8.dp))
     }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/composables/dividers/FCCSecondaryHorizontalDivider.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/composables/dividers/FCCSecondaryHorizontalDivider.kt
@@ -16,3 +16,11 @@ fun FCCSecondaryHorizontalDivider(modifier: Modifier = Modifier) {
     )
 }
 
+@Composable
+fun FCCThickSecondaryHorizontalDivider(modifier: Modifier = Modifier) {
+    HorizontalDivider(
+        modifier.fillMaxWidth(),
+        thickness = (1.5).dp,
+        color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.7f)
+    )
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/FCCTextField.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/FCCTextField.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
@@ -17,7 +18,9 @@ fun FCCTextField(
     value: String,
     modifier: Modifier = Modifier,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
     singleLine: Boolean = true,
+    suffix: @Composable (() -> Unit)? = null,
     maxLines: Int = 1,
     onValueChange: (String) -> Unit,
 ) {
@@ -36,8 +39,10 @@ fun FCCTextField(
             value = value,
             singleLine = singleLine,
             maxLines = maxLines,
+            suffix = suffix,
             onValueChange = { onValueChange(it) },
-            keyboardOptions = keyboardOptions
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions
         )
     }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/FCCTextField.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/FCCTextField.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -14,13 +16,14 @@ import com.erdees.foodcostcalc.ui.composables.labels.FieldLabel
 
 @Composable
 fun FCCTextField(
-    title: String,
+    title: String?,
     value: String,
     modifier: Modifier = Modifier,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     singleLine: Boolean = true,
     suffix: @Composable (() -> Unit)? = null,
+    placeholder: String? = null,
     maxLines: Int = 1,
     onValueChange: (String) -> Unit,
 ) {
@@ -30,16 +33,27 @@ fun FCCTextField(
         Modifier.fillMaxSize()
     }
     Column(modifier) {
-        FieldLabel(
-            text = title,
-            modifier = Modifier.padding(bottom = 4.dp)
-        )
+        title?.let {
+            FieldLabel(
+                text = title,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+        }
+
         OutlinedTextField(
             modifier = outlinedTextFieldModifier,
             value = value,
             singleLine = singleLine,
             maxLines = maxLines,
             suffix = suffix,
+            placeholder = {
+                placeholder?.let {
+                    Text(
+                        text = it,
+                        color = LocalContentColor.current.copy(alpha = 0.5f)
+                    )
+                }
+            },
             onValueChange = { onValueChange(it) },
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/FCCTextFieldWithSuggestions.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/FCCTextFieldWithSuggestions.kt
@@ -53,16 +53,18 @@ import androidx.compose.ui.window.PopupProperties
  */
 @Composable
 fun <T> FCCTextFieldWithSuggestions(
-    title: String,
+    title: String?,
     value: String,
     onValueChange: (String) -> Unit,
     suggestions: List<T>,
+    shouldShowSuggestions: Boolean,
     onSuggestionSelected: (T) -> Unit,
     modifier: Modifier = Modifier,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
+    placeholder: String? = null,
     suggestionItemContent: @Composable (T) -> Unit,
-    shouldShowSuggestions: Boolean,
+
     onDismissSuggestions: () -> Unit,
     focusRequester: FocusRequester = remember { FocusRequester() }
 ) {
@@ -84,6 +86,7 @@ fun <T> FCCTextFieldWithSuggestions(
                 },
             title = title,
             value = value,
+            placeholder = placeholder,
             onValueChange = onValueChange,
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/FCCTextFieldWithSuggestions.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/FCCTextFieldWithSuggestions.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.window.PopupProperties
  * @param onValueChange Callback invoked when the text value of the text field changes.
  *                      The new text value is provided as a parameter.
  * @param suggestions A list of items of type `T` to be displayed as suggestions.
- * @param onSuggestionSelected Callback invoked when a suggestion is selected from the dropdown.
+ * @param onSuggestionSelect Callback invoked when a suggestion is selected from the dropdown.
  *                             The selected suggestion of type `T` is provided as a parameter.
  * @param modifier Optional [Modifier] to be applied to the root Box composable.
  * @param keyboardOptions Optional [KeyboardOptions] to configure the software keyboard.
@@ -58,15 +58,14 @@ fun <T> FCCTextFieldWithSuggestions(
     onValueChange: (String) -> Unit,
     suggestions: List<T>,
     shouldShowSuggestions: Boolean,
-    onSuggestionSelected: (T) -> Unit,
     modifier: Modifier = Modifier,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     placeholder: String? = null,
-    suggestionItemContent: @Composable (T) -> Unit,
-
-    onDismissSuggestions: () -> Unit,
-    focusRequester: FocusRequester = remember { FocusRequester() }
+    focusRequester: FocusRequester = remember { FocusRequester() },
+    onSuggestionSelect: (T) -> Unit  = {},
+    suggestionItemContent: @Composable (T) -> Unit = {},
+    onDismissSuggestions: () -> Unit = {},
 ) {
     var textFieldWidth by remember { mutableStateOf(0.dp) }
     val density = LocalDensity.current
@@ -114,7 +113,7 @@ fun <T> FCCTextFieldWithSuggestions(
                             suggestionItemContent(suggestion)
                         },
                         onClick = {
-                            onSuggestionSelected(suggestion)
+                            onSuggestionSelect(suggestion)
                             focusManager.clearFocus()
                         }
                     )

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/FCCTextFieldWithSuggestions.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/FCCTextFieldWithSuggestions.kt
@@ -1,0 +1,122 @@
+package com.erdees.foodcostcalc.ui.composables.fields
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupProperties
+
+/**
+ * A Composable function that provides a text field with suggestions displayed in a dropdown.
+ *
+ * This component combines a standard `FCCTextField` with a list of suggestions that appear
+ * below the text field when `shouldShowSuggestions` is true and `suggestions` is not empty.
+ * Users can type in the text field and select a suggestion from the list.
+ *
+ * @param T The type of the items in the suggestions list.
+ * @param title The label displayed above the text field.
+ * @param value The current text value of the text field.
+ * @param onValueChange Callback invoked when the text value of the text field changes.
+ *                      The new text value is provided as a parameter.
+ * @param suggestions A list of items of type `T` to be displayed as suggestions.
+ * @param onSuggestionSelected Callback invoked when a suggestion is selected from the dropdown.
+ *                             The selected suggestion of type `T` is provided as a parameter.
+ * @param modifier Optional [Modifier] to be applied to the root Box composable.
+ * @param keyboardOptions Optional [KeyboardOptions] to configure the software keyboard.
+ *                        Defaults to [KeyboardOptions.Default].
+ * @param keyboardActions Optional [KeyboardActions] to define actions for the software keyboard.
+ *                        Defaults to [KeyboardActions.Default].
+ * @param suggestionItemContent A Composable lambda that defines how each suggestion item is rendered
+ *                              in the dropdown. It receives a suggestion of type `T` as a parameter.
+ * @param shouldShowSuggestions A boolean indicating whether the suggestions dropdown should be visible.
+ * @param onDismissSuggestions Callback invoked when the suggestions dropdown is dismissed (e.g., by
+ *                             clicking outside or when the text field loses focus and suggestions were showing).
+ * @param focusRequester Optional [FocusRequester] to control the focus of the text field.
+ *                       Defaults to a remembered `FocusRequester`.
+ */
+@Composable
+fun <T> FCCTextFieldWithSuggestions(
+    title: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    suggestions: List<T>,
+    onSuggestionSelected: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    suggestionItemContent: @Composable (T) -> Unit,
+    shouldShowSuggestions: Boolean,
+    onDismissSuggestions: () -> Unit,
+    focusRequester: FocusRequester = remember { FocusRequester() }
+) {
+    var textFieldWidth by remember { mutableStateOf(0.dp) }
+    val density = LocalDensity.current
+    val focusManager = LocalFocusManager.current
+
+    Box(modifier = modifier) {
+        FCCTextField(
+            modifier = Modifier
+                .focusRequester(focusRequester)
+                .onSizeChanged {
+                    textFieldWidth = with(density) { it.width.toDp() }
+                }
+                .onFocusChanged { focusState ->
+                    if (!focusState.isFocused && shouldShowSuggestions) {
+                        onDismissSuggestions()
+                    }
+                },
+            title = title,
+            value = value,
+            onValueChange = onValueChange,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            singleLine = true,
+            maxLines = 1
+        )
+
+        if (shouldShowSuggestions && suggestions.isNotEmpty()) {
+            DropdownMenu(
+                expanded = true,
+                onDismissRequest = {
+                    onDismissSuggestions()
+                },
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                modifier = Modifier.width(textFieldWidth),
+                properties = PopupProperties(
+                    focusable = false,
+                )
+            ) {
+                suggestions.forEach { suggestion ->
+                    DropdownMenuItem(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        text = {
+                            suggestionItemContent(suggestion)
+                        },
+                        onClick = {
+                            onSuggestionSelected(suggestion)
+                            focusManager.clearFocus()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/UnitField.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/UnitField.kt
@@ -24,25 +24,46 @@ import com.erdees.foodcostcalc.R
 import com.erdees.foodcostcalc.ui.composables.labels.FieldLabel
 
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun UnitField(
     units: Set<String>,
     selectedUnit: String,
     modifier: Modifier = Modifier,
-    selectUnit: (String) -> Unit
+    selectUnit: (String) -> Unit,
+    label: String = stringResource(id = R.string.unit)
 ) {
     var expanded by remember { mutableStateOf(false) }
+    UnitField(
+        expanded = expanded,
+        units = units,
+        label = label,
+        selectedUnit = selectedUnit,
+        modifier = modifier,
+        selectUnit = selectUnit,
+        onExpandChange = { expanded = it },
+    )
+}
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UnitField(
+    expanded: Boolean,
+    units: Set<String>,
+    selectedUnit: String,
+    modifier: Modifier = Modifier,
+    onExpandChange: (Boolean) -> Unit,
+    selectUnit: (String) -> Unit,
+    label: String = stringResource(id = R.string.unit)
+){
     Column(modifier = modifier) {
         FieldLabel(
-            text = stringResource(id = R.string.unit),
+            text = label,
             modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)
         )
         Box {
             ExposedDropdownMenuBox(
                 expanded = expanded,
-                onExpandedChange = { expanded = it },
+                onExpandedChange = { onExpandChange(it) },
             ) {
 
                 TextField(
@@ -60,11 +81,11 @@ fun UnitField(
                 DropdownMenu(
                     modifier = Modifier.exposedDropdownSize(true),
                     expanded = expanded,
-                    onDismissRequest = { expanded = false }) {
+                    onDismissRequest = { onExpandChange(false)}) {
                     units.forEach { unit ->
                         DropdownMenuItem(onClick = {
                             selectUnit(unit)
-                            expanded = false
+                            onExpandChange(false)
                         }, text = {
                             Text(unit)
                         })

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/UnitField.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/composables/fields/UnitField.kt
@@ -29,8 +29,8 @@ fun UnitField(
     units: Set<String>,
     selectedUnit: String,
     modifier: Modifier = Modifier,
-    selectUnit: (String) -> Unit,
-    label: String = stringResource(id = R.string.unit)
+    label: String = stringResource(id = R.string.unit),
+    selectUnit: (String) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
     UnitField(
@@ -51,9 +51,9 @@ fun UnitField(
     units: Set<String>,
     selectedUnit: String,
     modifier: Modifier = Modifier,
-    onExpandChange: (Boolean) -> Unit,
-    selectUnit: (String) -> Unit,
-    label: String = stringResource(id = R.string.unit)
+    label: String = stringResource(id = R.string.unit),
+    onExpandChange: (Boolean) -> Unit = {},
+    selectUnit: (String) -> Unit = {},
 ){
     Column(modifier = modifier) {
         FieldLabel(

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/errors/UserReportableError.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/errors/UserReportableError.kt
@@ -1,0 +1,26 @@
+package com.erdees.foodcostcalc.ui.errors
+
+import androidx.annotation.StringRes
+import com.erdees.foodcostcalc.R
+
+interface UserReportableError {
+    @get:StringRes
+    val errorRes: Int
+
+    val message: String?
+}
+
+class InvalidMarginFormatException(
+    message: String,
+    @StringRes override val errorRes: Int = R.string.invalid_margin_format_error
+) : IllegalArgumentException(message), UserReportableError
+
+class InvalidTaxFormatException(
+    message: String,
+    @StringRes override val errorRes: Int = R.string.invalid_tax_format_error
+) : IllegalArgumentException(message), UserReportableError
+
+class InvalidProductPriceException(
+    message: String,
+    @StringRes override val errorRes: Int = R.string.invalid_product_price_error
+) : IllegalArgumentException(message), UserReportableError

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/ConfirmAndNavigate.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/ConfirmAndNavigate.kt
@@ -1,24 +1,37 @@
 package com.erdees.foodcostcalc.ui.navigation
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseIn
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathMeasure
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -33,33 +46,65 @@ import kotlin.math.sin
 
 @Composable
 fun ConfirmAndNavigate(
+    visible: Boolean,
+    modifier: Modifier = Modifier,
     progress: Float = 0f,
     navigate: () -> Unit = {},
 ) {
-
     val context = LocalContext.current
+    val configuration = LocalWindowInfo.current
+    val screenWidth = configuration.containerSize.width.dp
+    val screenHeight = configuration.containerSize.height.dp
     val checkmarkProgress = remember { Animatable(progress) }
-
     val animationDuration = 300
-    LaunchedEffect(Unit) {
-        context.vibrateForConfirmation()
-        checkmarkProgress.animateTo(
-            targetValue = 1f,
-            animationSpec = tween(
-                durationMillis = animationDuration,
-                easing = EaseIn
+
+    val cornerRadius by animateIntAsState(
+        targetValue = if (visible) 0 else 100,
+        animationSpec = tween(durationMillis = animationDuration)
+    )
+
+    val width by animateDpAsState(
+        targetValue = if (visible) screenWidth else 100.dp,
+        animationSpec = tween(durationMillis = animationDuration  * 2, easing = EaseIn)
+    )
+
+    val height by animateDpAsState(
+        targetValue = if (visible) screenHeight else 100.dp,
+        animationSpec = tween(durationMillis = animationDuration * 2, easing = EaseIn)
+    )
+    
+    LaunchedEffect(visible) {
+        if (visible) {
+            context.vibrateForConfirmation()
+            checkmarkProgress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(
+                    durationMillis = animationDuration,
+                    easing = EaseIn
+                )
             )
-        )
-        delay(animationDuration * 2L)
-        navigate()
+            delay(animationDuration * 2L)
+            navigate()
+        }
     }
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.Center
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + scaleIn(initialScale = 0.2f),
+        exit = fadeOut()
     ) {
-        CheckmarkAnimation(progress = checkmarkProgress.value)
+        Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Box(
+                modifier = Modifier
+                    .width(width)
+                    .height(height)
+                    .clip(RoundedCornerShape(percent = cornerRadius))
+                    .background(MaterialTheme.colorScheme.scrim.copy(0.4f)),
+                contentAlignment = Alignment.Center
+            ) {
+                CheckmarkAnimation(progress = checkmarkProgress.value)
+            }
+        }
     }
 }
 
@@ -71,7 +116,8 @@ fun CheckmarkAnimation(progress: Float) {
         val canvasWidth = size.width
         val canvasHeight = size.height
         val center = Offset(canvasWidth / 2, canvasHeight / 2)
-        val radius = size.minDimension / 2.5f // Radius for the main circle, adjusted for cookie shape
+        val radius =
+            size.minDimension / 2.5f // Radius for the main circle, adjusted for cookie shape
 
         // 1. Define the "sharp cookie" path (star-like or gear-like)
         val cookiePath = Path().apply {
@@ -111,10 +157,10 @@ fun CheckmarkAnimation(progress: Float) {
             // These values define the checkmark's shape and position within the circle
             val startX = center.x - radius * 0.48f  // Adjusted for visual centering
             val startY = center.y + radius * 0.05f  // Adjusted for visual centering
-            val midX =   center.x - radius * 0.06f  // Adjusted for visual centering
-            val midY =   center.y + radius * 0.38f  // Adjusted for visual centering
-            val endX =   center.x + radius * 0.48f  // Adjusted for visual centering
-            val endY =   center.y - radius * 0.28f  // Adjusted for visual centering
+            val midX = center.x - radius * 0.06f  // Adjusted for visual centering
+            val midY = center.y + radius * 0.38f  // Adjusted for visual centering
+            val endX = center.x + radius * 0.48f  // Adjusted for visual centering
+            val endY = center.y - radius * 0.28f  // Adjusted for visual centering
 
             moveTo(startX, startY)
             lineTo(midX, midY)
@@ -141,14 +187,13 @@ class ProgressPreviewParameterProvider : PreviewParameterProvider<Float> {
     override val values = sequenceOf(0f, 0.5f, 1f)
 }
 
-@Preview
 @PreviewLightDark
 @Composable
 fun ConfirmAndNavigate_ProgressPreview(
     @PreviewParameter(ProgressPreviewParameterProvider::class) progress: Float
 ) {
     FCCTheme {
-        ConfirmAndNavigate(progress = progress)
+        ConfirmAndNavigate(true, progress = progress, modifier = Modifier.size(200.dp))
     }
 }
 
@@ -158,10 +203,9 @@ fun ConfirmAndNavigate_ProgressPreview(
  * For full interaction, use an interactive preview mode or run on an emulator/device.
  */
 @Preview(name = "Interactive ConfirmAndNavigate")
-@PreviewLightDark
 @Composable
 fun InteractiveConfirmAndNavigatePreview() {
     FCCTheme {
-            ConfirmAndNavigate()
+        ConfirmAndNavigate(true)
     }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/ConfirmAndNavigate.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/ConfirmAndNavigate.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,6 +45,7 @@ import kotlin.math.cos
 import kotlin.math.sin
 
 
+@Suppress("MagicNumber")
 @Composable
 fun ConfirmAndNavigate(
     visible: Boolean,
@@ -57,6 +59,7 @@ fun ConfirmAndNavigate(
     val screenHeight = configuration.containerSize.height.dp
     val checkmarkProgress = remember { Animatable(progress) }
     val animationDuration = 300
+    val currentNavigate by rememberUpdatedState(newValue = navigate)
 
     val cornerRadius by animateIntAsState(
         targetValue = if (visible) 0 else 100,
@@ -65,14 +68,14 @@ fun ConfirmAndNavigate(
 
     val width by animateDpAsState(
         targetValue = if (visible) screenWidth else 100.dp,
-        animationSpec = tween(durationMillis = animationDuration  * 2, easing = EaseIn)
+        animationSpec = tween(durationMillis = animationDuration * 2, easing = EaseIn)
     )
 
     val height by animateDpAsState(
         targetValue = if (visible) screenHeight else 100.dp,
         animationSpec = tween(durationMillis = animationDuration * 2, easing = EaseIn)
     )
-    
+
     LaunchedEffect(visible) {
         if (visible) {
             context.vibrateForConfirmation()
@@ -84,7 +87,7 @@ fun ConfirmAndNavigate(
                 )
             )
             delay(animationDuration * 2L)
-            navigate()
+            currentNavigate()
         }
     }
 
@@ -108,11 +111,12 @@ fun ConfirmAndNavigate(
     }
 }
 
+@Suppress("MagicNumber")
 @Composable
-fun CheckmarkAnimation(progress: Float) {
+fun CheckmarkAnimation(progress: Float, modifier: Modifier = Modifier) {
     val cookieColor = MaterialTheme.colorScheme.primaryContainer
     val checkmarkColor = MaterialTheme.colorScheme.primary
-    Canvas(modifier = Modifier.size(120.dp)) { // Increased size slightly for cookie shape padding
+    Canvas(modifier = modifier.size(120.dp)) {
         val canvasWidth = size.width
         val canvasHeight = size.height
         val center = Offset(canvasWidth / 2, canvasHeight / 2)
@@ -188,8 +192,9 @@ class ProgressPreviewParameterProvider : PreviewParameterProvider<Float> {
 }
 
 @PreviewLightDark
+@Preview
 @Composable
-fun ConfirmAndNavigate_ProgressPreview(
+private fun ConfirmAndNavigate_ProgressPreview(
     @PreviewParameter(ProgressPreviewParameterProvider::class) progress: Float
 ) {
     FCCTheme {
@@ -204,7 +209,7 @@ fun ConfirmAndNavigate_ProgressPreview(
  */
 @Preview(name = "Interactive ConfirmAndNavigate")
 @Composable
-fun InteractiveConfirmAndNavigatePreview() {
+private fun InteractiveConfirmAndNavigatePreview() {
     FCCTheme {
         ConfirmAndNavigate(true)
     }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/ConfirmAndNavigate.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/ConfirmAndNavigate.kt
@@ -1,0 +1,167 @@
+package com.erdees.foodcostcalc.ui.navigation
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.EaseIn
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathMeasure
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.erdees.foodcostcalc.ext.vibrateForConfirmation
+import com.erdees.foodcostcalc.ui.theme.FCCTheme
+import kotlinx.coroutines.delay
+import kotlin.math.cos
+import kotlin.math.sin
+
+
+@Composable
+fun ConfirmAndNavigate(
+    progress: Float = 0f,
+    navigate: () -> Unit = {},
+) {
+
+    val context = LocalContext.current
+    val checkmarkProgress = remember { Animatable(progress) }
+
+    val animationDuration = 300
+    LaunchedEffect(Unit) {
+        context.vibrateForConfirmation()
+        checkmarkProgress.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(
+                durationMillis = animationDuration,
+                easing = EaseIn
+            )
+        )
+        delay(animationDuration * 2L)
+        navigate()
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CheckmarkAnimation(progress = checkmarkProgress.value)
+    }
+}
+
+@Composable
+fun CheckmarkAnimation(progress: Float) {
+    val cookieColor = MaterialTheme.colorScheme.primaryContainer
+    val checkmarkColor = MaterialTheme.colorScheme.primary
+    Canvas(modifier = Modifier.size(120.dp)) { // Increased size slightly for cookie shape padding
+        val canvasWidth = size.width
+        val canvasHeight = size.height
+        val center = Offset(canvasWidth / 2, canvasHeight / 2)
+        val radius = size.minDimension / 2.5f // Radius for the main circle, adjusted for cookie shape
+
+        // 1. Define the "sharp cookie" path (star-like or gear-like)
+        val cookiePath = Path().apply {
+            val numPoints = 24 // Number of points for the star/cookie
+            val outerRadius = size.minDimension / 2 // Outer boundary of the cookie points
+            val innerRadius = radius * 1.4f // Inner dips of the cookie shape
+
+            for (i in 0 until numPoints * 2) {
+                val currentRadius = if (i % 2 == 0) outerRadius else innerRadius
+                // Ensure angle calculation is correct for starting point (e.g., top) and direction
+                val angle = (Math.PI / numPoints * i).toFloat() - (Math.PI / 2).toFloat()
+                val x = center.x + cos(angle) * currentRadius
+                val y = center.y + sin(angle) * currentRadius
+                if (i == 0) moveTo(x, y) else lineTo(x, y)
+            }
+            close()
+        }
+
+        // 2. Draw the cookie shape as the background
+        drawPath(
+            path = cookiePath,
+            color = cookieColor
+        )
+
+        // 3. Draw the progress circle INSIDE the cookie shape
+        val circleColor = checkmarkColor
+        drawCircle(
+            color = circleColor,
+            radius = radius,
+            center = center,
+            style = Stroke(width = 14f)
+        )
+
+        // 4. Define and draw the checkmark path (relative to the center of the canvas)
+        val checkmarkPath = Path().apply {
+            // Adjust coordinates to be relative to the center and scaled by the inner circle's radius
+            // These values define the checkmark's shape and position within the circle
+            val startX = center.x - radius * 0.48f  // Adjusted for visual centering
+            val startY = center.y + radius * 0.05f  // Adjusted for visual centering
+            val midX =   center.x - radius * 0.06f  // Adjusted for visual centering
+            val midY =   center.y + radius * 0.38f  // Adjusted for visual centering
+            val endX =   center.x + radius * 0.48f  // Adjusted for visual centering
+            val endY =   center.y - radius * 0.28f  // Adjusted for visual centering
+
+            moveTo(startX, startY)
+            lineTo(midX, midY)
+            lineTo(endX, endY)
+        }
+
+        val pathMeasure = PathMeasure()
+        pathMeasure.setPath(checkmarkPath, false)
+        val pathLength = pathMeasure.length
+        val drawnPath = Path()
+        if (pathLength > 0f) {
+            pathMeasure.getSegment(0f, pathLength * progress.coerceIn(0f, 1f), drawnPath, true)
+        }
+
+        drawPath(
+            path = drawnPath,
+            color = checkmarkColor,
+            style = Stroke(width = 16f, cap = StrokeCap.Round)
+        )
+    }
+}
+
+class ProgressPreviewParameterProvider : PreviewParameterProvider<Float> {
+    override val values = sequenceOf(0f, 0.5f, 1f)
+}
+
+@Preview
+@PreviewLightDark
+@Composable
+fun ConfirmAndNavigate_ProgressPreview(
+    @PreviewParameter(ProgressPreviewParameterProvider::class) progress: Float
+) {
+    FCCTheme {
+        ConfirmAndNavigate(progress = progress)
+    }
+}
+
+/**
+ * Interactive preview to see the transition from button to animation.
+ * Note: Full animation and navigation won't work perfectly in a typical static preview.
+ * For full interaction, use an interactive preview mode or run on an emulator/device.
+ */
+@Preview(name = "Interactive ConfirmAndNavigate")
+@PreviewLightDark
+@Composable
+fun InteractiveConfirmAndNavigatePreview() {
+    FCCTheme {
+            ConfirmAndNavigate()
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/FCCNavigation.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/FCCNavigation.kt
@@ -1,5 +1,7 @@
 package com.erdees.foodcostcalc.ui.navigation
 
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
@@ -109,11 +111,18 @@ fun FCCNavigation(
             CreateDishScreen(navController = navController)
         }
 
-        composable<FCCScreen.CreateDishStart> {
+        composable<FCCScreen.CreateDishStart>(
+            exitTransition = { slideOutHorizontally(targetOffsetX = { -it }) },
+            popEnterTransition = { slideInHorizontally(initialOffsetX = { -it }) },
+            popExitTransition = null
+        ) {
             CreateDishStartScreen(navController = navController)
         }
 
-        composable<FCCScreen.CreateDishSummary> { backStackEntry ->
+        composable<FCCScreen.CreateDishSummary>(
+            enterTransition = { slideInHorizontally { it } },
+            popExitTransition = { slideOutHorizontally { it }}
+        ) { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
                 navController.getBackStackEntry(navController.previousBackStackEntry?.destination?.route.toString())
             }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/FCCNavigation.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/FCCNavigation.kt
@@ -15,6 +15,9 @@ import androidx.navigation.toRoute
 import com.erdees.foodcostcalc.ui.screens.dishes.DishesScreen
 import com.erdees.foodcostcalc.ui.screens.dishes.addItemToDish.AddItemToDishScreen
 import com.erdees.foodcostcalc.ui.screens.dishes.createDish.CreateDishScreen
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.CreateDishV2ViewModel
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.CreateDishStartScreen
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishSummary.CreateDishSummaryScreen
 import com.erdees.foodcostcalc.ui.screens.dishes.editDish.DishDetailsViewModel
 import com.erdees.foodcostcalc.ui.screens.dishes.editDish.EditDishScreen
 import com.erdees.foodcostcalc.ui.screens.featureRequest.FeatureRequestScreen
@@ -82,7 +85,7 @@ fun FCCNavigation(
             EditDishScreen(dishId = route.dishId, navController = navController)
         }
 
-         composable<FCCScreen.Recipe> { backStackEntry ->
+        composable<FCCScreen.Recipe> { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
                 navController.getBackStackEntry(navController.previousBackStackEntry?.destination?.route.toString())
             }
@@ -104,6 +107,19 @@ fun FCCNavigation(
         }
         composable<FCCScreen.CreateDish> {
             CreateDishScreen(navController = navController)
+        }
+
+        composable<FCCScreen.CreateDishStart> {
+            CreateDishStartScreen(navController = navController)
+        }
+
+        composable<FCCScreen.CreateDishSummary> { backStackEntry ->
+            val parentEntry = remember(backStackEntry) {
+                navController.getBackStackEntry(navController.previousBackStackEntry?.destination?.route.toString())
+            }
+
+            val viewModel = viewModel<CreateDishV2ViewModel>(parentEntry)
+            CreateDishSummaryScreen(navController, viewModel)
         }
 
         composable<FCCScreen.EditProduct> { backStackEntry ->

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/FCCScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/FCCScreen.kt
@@ -51,6 +51,12 @@ sealed class FCCScreen(
     data object CreateDish : FCCScreen()
 
     @Serializable
+    data object CreateDishStart : FCCScreen()
+
+    @Serializable
+    data object CreateDishSummary : FCCScreen()
+
+    @Serializable
     data class EditHalfProduct(val halfProductId: Long) : FCCScreen()
 
     @Serializable

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/DishesScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/DishesScreen.kt
@@ -130,7 +130,7 @@ fun DishesScreen(navController: NavController, viewModel: DishesScreenViewModel 
                 isVisible = isVisible.value,
                 contentDescription = stringResource(id = R.string.content_description_create_dish)
             ) {
-                navController.navigate(FCCScreen.CreateDish)
+                navController.navigate(FCCScreen.CreateDishStart)
             }
         }
     }) { paddingValues ->
@@ -141,7 +141,7 @@ fun DishesScreen(navController: NavController, viewModel: DishesScreenViewModel 
             listItems?.let { listItems ->
                 if (isEmptyListContentVisible) {
                     EmptyListContent(screen = FCCScreen.Dishes) {
-                        navController.navigate(FCCScreen.CreateDish)
+                        navController.navigate(FCCScreen.CreateDishStart)
                     }
                 } else {
                     DishesScreenContent(

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/CreateDishV2ViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/CreateDishV2ViewModel.kt
@@ -441,4 +441,12 @@ class CreateDishV2ViewModel : FCCBaseViewModel(), KoinComponent {
     fun dismissError() {
         _errorRes.value = null
     }
+
+    /**
+     * Resets the save dish success state to prevent re-navigation.
+     * Call this after navigation has been handled.
+     */
+    fun resetSaveDishSuccess() {
+        _saveDishSuccess.value = null
+    }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/CreateDishV2ViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/CreateDishV2ViewModel.kt
@@ -57,6 +57,10 @@ class CreateDishV2ViewModel : FCCBaseViewModel(), KoinComponent {
     private var _isLoading: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isLoading = _isLoading.asStateFlow()
 
+    val isFirstDish: StateFlow<Boolean> = dishRepository.dishes.map {
+        it.isEmpty()
+    }.stateIn(viewModelScope, Eagerly, true)
+
     @StringRes
     private var _errorRes: MutableStateFlow<Int?> = MutableStateFlow(null)
 

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/CreateDishV2ViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/CreateDishV2ViewModel.kt
@@ -292,7 +292,7 @@ class CreateDishV2ViewModel : FCCBaseViewModel(), KoinComponent {
         viewModelScope.launch {
             try {
                 val productDomain = selectedSuggestedProduct.value
-                    ?: throw IllegalStateException("Attempted to add existing product but no product was selected.")
+                    ?: error("Attempted to add existing product but no product was selected.")
 
                 addProductToDishList(
                     product = productDomain,
@@ -318,7 +318,7 @@ class CreateDishV2ViewModel : FCCBaseViewModel(), KoinComponent {
      */
     private fun addProductToDishList(product: ProductDomain, quantityStr: String, unit: String) {
         val quantityAddedToDish = quantityStr.toDoubleOrNull()
-            ?: throw IllegalStateException("Quantity for the product in the dish cannot be empty or invalid.")
+            ?: error("Quantity for the product in the dish cannot be empty or invalid.")
 
         val productAddedToDish = ProductAddedToDish(
             item = product,

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/CreateDishV2ViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/CreateDishV2ViewModel.kt
@@ -1,0 +1,425 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.viewModelScope
+import com.erdees.foodcostcalc.R
+import com.erdees.foodcostcalc.data.Preferences
+import com.erdees.foodcostcalc.data.model.local.DishBase
+import com.erdees.foodcostcalc.data.model.local.ProductBase
+import com.erdees.foodcostcalc.data.repository.AnalyticsRepository
+import com.erdees.foodcostcalc.data.repository.DishRepository
+import com.erdees.foodcostcalc.data.repository.ProductRepository
+import com.erdees.foodcostcalc.domain.mapper.Mapper.toProductDish
+import com.erdees.foodcostcalc.domain.mapper.Mapper.toProductDomain
+import com.erdees.foodcostcalc.domain.model.product.ProductAddedToDish
+import com.erdees.foodcostcalc.domain.model.product.ProductDomain
+import com.erdees.foodcostcalc.ui.errors.InvalidMarginFormatException
+import com.erdees.foodcostcalc.ui.errors.InvalidProductPriceException
+import com.erdees.foodcostcalc.ui.errors.InvalidTaxFormatException
+import com.erdees.foodcostcalc.ui.errors.UserReportableError
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.CreateDishIntent
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.existingProductForm.ExistingProductFormData
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.newProductForm.NewProductFormData
+import com.erdees.foodcostcalc.ui.viewModel.FCCBaseViewModel
+import com.erdees.foodcostcalc.utils.Constants.UI.SEARCH_DEBOUNCE_MS
+import com.erdees.foodcostcalc.utils.MyDispatchers
+import com.erdees.foodcostcalc.utils.Utils
+import com.erdees.foodcostcalc.utils.onNumericValueChange
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.SharingStarted.Companion.Eagerly
+import kotlinx.coroutines.flow.SharingStarted.Companion.Lazily
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import timber.log.Timber
+import java.util.Locale
+
+class CreateDishV2ViewModel : FCCBaseViewModel(), KoinComponent {
+
+    private val analyticsRepository: AnalyticsRepository by inject()
+    private val productRepository: ProductRepository by inject()
+    private val dishRepository: DishRepository by inject()
+    private val preferences: Preferences by inject()
+    private val dispatchers: MyDispatchers by inject()
+
+    private var _isLoading: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isLoading = _isLoading.asStateFlow()
+
+    @StringRes
+    private var _errorRes: MutableStateFlow<Int?> = MutableStateFlow(null)
+
+    @StringRes
+    val errorRes = _errorRes.asStateFlow()
+
+    private var _saveDishSuccess: MutableStateFlow<Long?> = MutableStateFlow(null)
+
+    /**
+     * Emits the ID of the dish if it was successfully saved to the database, otherwise null.
+     * */
+    val saveDishSuccess = _saveDishSuccess.asStateFlow()
+
+    private var _intent: MutableStateFlow<CreateDishIntent?> = MutableStateFlow(null)
+    val intent = _intent.asStateFlow()
+
+    val currency = preferences.currency.stateIn(viewModelScope, Lazily, null)
+
+    val products: StateFlow<List<ProductDomain>> =
+        productRepository.products.map { list ->
+            list.map { it.toProductDomain() }
+        }.stateIn(
+            viewModelScope,
+            Lazily,
+            listOf()
+        )
+
+    private val _addedProducts: MutableStateFlow<List<ProductAddedToDish>> =
+        MutableStateFlow(listOf())
+    val addedProducts = _addedProducts.asStateFlow()
+
+    private var _dishName = MutableStateFlow("")
+    val dishName = _dishName
+
+    fun updateDishName(newValue: String) {
+        _dishName.value = newValue
+    }
+
+    private val _marginPercentInput: MutableStateFlow<String> = MutableStateFlow("")
+    val marginPercentInput: StateFlow<String> = _marginPercentInput.onStart {
+        _marginPercentInput.value = preferences.defaultMargin.first()
+    }.stateIn(
+        viewModelScope, Eagerly, ""
+    )
+
+    fun updateMarginPercentInput(newMargin: String) {
+        onNumericValueChange(newMargin, _marginPercentInput)
+    }
+
+    private val _taxPercentInput = MutableStateFlow(preferences.defaultTax.toString())
+    val taxPercentInput: StateFlow<String> = _taxPercentInput.onStart {
+        _taxPercentInput.value = preferences.defaultTax.first()
+    }.stateIn(
+        viewModelScope, Eagerly, ""
+    )
+
+    fun updateTaxPercentInput(newTax: String) {
+        onNumericValueChange(newTax, _taxPercentInput)
+    }
+
+    private val _newProductName = MutableStateFlow("")
+    val newProductName = _newProductName
+
+    fun updateNewProductName(newValue: String) {
+        suggestionsManuallyDismissed.value = false
+        if (newValue.isBlank()) {
+            selectedSuggestedProduct.value = null
+        }
+
+        val productNameMatchesExistingProduct = products.value.find { it.name == newValue }
+        if (productNameMatchesExistingProduct == null) {
+            selectedSuggestedProduct.value = null
+        } else {
+            selectedSuggestedProduct.value = productNameMatchesExistingProduct
+        }
+
+        _newProductName.value = newValue
+    }
+
+    val selectedSuggestedProduct = MutableStateFlow<ProductDomain?>(null)
+
+    private val suggestionsManuallyDismissed = MutableStateFlow(false)
+
+    fun onSuggestionsManuallyDismissed() {
+        suggestionsManuallyDismissed.value = true
+    }
+
+    @OptIn(FlowPreview::class)
+    val suggestedProducts =
+        combine(
+            products,
+            newProductName.debounce(SEARCH_DEBOUNCE_MS)
+                .onStart { emit("") }) { products, searchWord ->
+            products.filter {
+                it.name.lowercase(Locale.getDefault()).contains(searchWord.lowercase())
+            }
+        }.stateIn(
+            scope = viewModelScope, started = Lazily, initialValue = null
+        )
+
+    @OptIn(FlowPreview::class)
+    val shouldShowSuggestedProducts = combine(
+        newProductName.debounce(SEARCH_DEBOUNCE_MS),
+        suggestedProducts,
+        selectedSuggestedProduct,
+        suggestionsManuallyDismissed
+    ) { newProductName, suggestedProducts, selectedSuggestedProduct, suggestionsManuallyDismissed ->
+        newProductName.isNotBlank() &&
+                newProductName.length > 2 &&
+                suggestedProducts?.isNotEmpty() == true &&
+                selectedSuggestedProduct == null &&
+                !suggestionsManuallyDismissed
+    }.stateIn(
+        scope = viewModelScope, started = Lazily, initialValue = false
+    )
+
+    val foodCost: StateFlow<Double> = _addedProducts.map { products ->
+        products.sumOf { productAdded ->
+            productAdded.foodCost
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = 0.0
+    )
+
+    val finalSellingPrice: StateFlow<Double> = combine(
+        foodCost, // Use the derived foodCost StateFlow
+        marginPercentInput.filter { it.toDoubleOrNull() != null },
+        taxPercentInput.filter { it.toDoubleOrNull() != null }
+    ) { cost, marginStr, taxStr ->
+        val margin = marginStr.toDouble()
+        val tax = taxStr.toDouble()
+        if (cost <= 0.0) {
+            0.0
+        } else {
+            Utils.getDishFinalPrice(cost, margin, tax)
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = 0.0
+    )
+
+    fun onSuggestionSelected(product: ProductDomain) {
+        newProductName.value = product.name
+        selectedSuggestedProduct.value = product
+    }
+
+    /**
+     * Called when user clicks add new ingredient in parent form
+     * */
+    fun onAddIngredientClick() {
+        viewModelScope.launch {
+            val productToAdd = selectedSuggestedProduct.value
+            if (productToAdd == null) {
+                _intent.update { CreateDishIntent.AddNewProduct(newProductName.value) }
+            } else {
+                _intent.update { CreateDishIntent.AddProduct(productToAdd) }
+            }
+        }
+    }
+
+    /**
+     * Called when the user submits the form to add a completely new product to the dish.
+     * It coordinates saving the new product to the database and then adding it to the current dish's ingredient list.
+     */
+    fun onAddNewProductClick(newProductFormData: NewProductFormData) {
+        _isLoading.update { true }
+        viewModelScope.launch(dispatchers.ioDispatcher) {
+            try {
+                val newlyCreatedProduct = addNewProductToRepository(newProductFormData)
+
+                addProductToDishList(
+                    newlyCreatedProduct,
+                    newProductFormData.quantityAddedToDish,
+                    newProductFormData.unitForDish
+                )
+
+                resetProductAdditionState()
+            } catch (e: Exception) {
+                handleError(e)
+            }
+        }
+    }
+
+    /**
+     * Creates a new ProductBase entity from the form data, saves it to the product repository,
+     * and returns the corresponding ProductDomain object.
+     *
+     * @param formData The data captured from the new product form.
+     * @return The ProductDomain representation of the newly created product.
+     * @throws IllegalStateException if essential data like price is missing.
+     */
+    private suspend fun addNewProductToRepository(formData: NewProductFormData): ProductDomain {
+        val price = formData.purchasePrice.toDoubleOrNull()
+            ?: throw InvalidProductPriceException("Product purchase price cannot be empty or invalid.")
+
+        val productBase = ProductBase(
+            productId = 0,
+            name = _newProductName.value,
+            pricePerUnit = price,
+            tax = 0.0,
+            waste = formData.wastePercent.toDoubleOrNull() ?: 0.0,
+            unit = formData.purchaseUnit
+        )
+        val newProductId = productRepository.addProduct(productBase)
+        return productBase.copy(productId = newProductId).toProductDomain()
+    }
+
+    /**
+     * Called when the user confirms adding a pre-existing, selected product to the current dish.
+     *
+     * @param existingProductFormData Data containing the quantity and unit for the product in the dish.
+     */
+    fun onAddExistingProductClick(existingProductFormData: ExistingProductFormData) {
+        _isLoading.update { true }
+        viewModelScope.launch {
+            try {
+                val productDomain = selectedSuggestedProduct.value
+                    ?: throw IllegalStateException("Attempted to add existing product but no product was selected.")
+
+                addProductToDishList(
+                    product = productDomain,
+                    quantityStr = existingProductFormData.quantityForDish,
+                    unit = existingProductFormData.unitForDish
+                )
+
+                resetProductAdditionState()
+            } catch (e: Exception) {
+                handleError(e)
+            }
+        }
+    }
+
+    /**
+     * Adds a given product (either newly created or existing) to the list of products
+     * currently added to the dish for UI display.
+     *
+     * @param product The ProductDomain object to add.
+     * @param quantityStr The quantity of this product to add to the dish.
+     * @param unit The unit for the quantity added to the dish.
+     * @throws IllegalStateException if the quantity is missing or invalid.
+     */
+    private fun addProductToDishList(product: ProductDomain, quantityStr: String, unit: String) {
+        val quantityAddedToDish = quantityStr.toDoubleOrNull()
+            ?: throw IllegalStateException("Quantity for the product in the dish cannot be empty or invalid.")
+
+        val productAddedToDish = ProductAddedToDish(
+            item = product,
+            quantity = quantityAddedToDish,
+            quantityUnit = unit
+        )
+        _addedProducts.update { currentList ->
+            currentList + productAddedToDish
+        }
+    }
+
+
+    /**
+     * Resets the state related to adding a new product to the dish.
+     * This function is typically called after a product (either new or existing)
+     * has been successfully processed and added to the list of ingredients for the current dish.
+     *
+     * It performs the following actions:
+     * - Sets the loading state (`_isLoading`) to `false`.
+     * - Clears the input field for the new product name (`_newProductName`).
+     * - Clears any selected product from suggestions (`selectedSuggestedProduct`).
+     * - Ensures that product suggestions are hidden by calling `onSuggestionsManuallyDismissed()`.
+     * - Dismisses any modal that might have been used for adding the product by calling `onModalDismissed()`.
+     */
+    private fun resetProductAdditionState() {
+        _isLoading.update { false }
+        _newProductName.value = ""
+        selectedSuggestedProduct.value = null
+        onSuggestionsManuallyDismissed() // Ensure suggestions are hidden
+        onModalDismissed() // If this is called from a modal, dismiss it
+    }
+
+    fun onModalDismissed() {
+        _intent.value = null
+    }
+
+    // In CreateDishV2ViewModel.kt
+
+    /**
+     * Handles the logic for saving the currently constructed dish and its ingredients to the database.
+     * It first saves the main dish entity, then iterates through the added products
+     * to save each as an ingredient linked to the dish.
+     */
+    fun onSaveDish() {
+        _isLoading.update { true }
+        viewModelScope.launch(dispatchers.ioDispatcher) {
+            try {
+                val dishId = saveDishBase()
+
+                saveDishIngredients(dishId)
+
+                _isLoading.update { false }
+                _saveDishSuccess.update { dishId }
+            } catch (e: Exception) {
+                Timber.e(e, "Error parsing margin or tax for saving dish.")
+                handleError(e)
+            }
+        }
+    }
+
+    /**
+     * Creates a [DishBase] object from the current ViewModel state (dish name, margin, tax)
+     * and saves it to the [dishRepository].
+     *
+     * @return The ID of the newly saved dish.
+     * @throws NumberFormatException if margin or tax percentages are not valid numbers.
+     */
+    private suspend fun saveDishBase(): Long {
+        val margin = marginPercentInput.value.toDoubleOrNull()
+            ?: throw InvalidMarginFormatException(
+                "Margin percentage is not a valid number: ${marginPercentInput.value}",
+            )
+        val tax = taxPercentInput.value.toDoubleOrNull()
+            ?: throw InvalidTaxFormatException("Tax percentage is not a valid number: ${taxPercentInput.value}")
+
+        val dish = DishBase(
+            dishId = 0,
+            name = dishName.value,
+            marginPercent = margin,
+            dishTax = tax,
+            recipeId = null
+        )
+        return dishRepository.addDish(dish)
+    }
+
+    /**
+     * Iterates through the list of products added to the dish ([_addedProducts])
+     * and saves each one as a [ProductDish] entity linked to the given [dishId]
+     * using the [productRepository].
+     *
+     * @param dishId The ID of the dish to which these ingredients belong.
+     */
+    private suspend fun saveDishIngredients(dishId: Long) {
+        _addedProducts.value.forEach { productAddedToDish ->
+            productRepository.addProductDish(productAddedToDish.toProductDish(dishId))
+        }
+    }
+
+    /**
+     * Handles common error logic by updating the error StateFlow and resetting the loading state.
+     *
+     * @param throwable The exception/throwable that occurred.
+     */
+    private fun handleError(throwable: Throwable) {
+        Timber.e(throwable)
+        _errorRes.update {
+            if (throwable is UserReportableError) {
+                throwable.errorRes
+            } else {
+                R.string.unexpected_error_occurred
+            }
+        }
+        _isLoading.update { false }
+    }
+
+    fun dismissError(){
+        _errorRes.value = null
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/DishCreationAnalyticsHelper.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/DishCreationAnalyticsHelper.kt
@@ -1,0 +1,134 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2
+
+import android.os.Bundle
+import com.erdees.foodcostcalc.data.repository.AnalyticsRepository
+import com.erdees.foodcostcalc.domain.model.product.ProductDomain
+import com.erdees.foodcostcalc.utils.Constants
+
+class DishCreationAnalyticsHelper(val analyticsRepository: AnalyticsRepository) {
+
+    fun logFlowStarted(){
+        analyticsRepository.logEvent(Constants.Analytics.DishV2.DISH_CREATION_STARTED, null)
+    }
+
+    fun logNewProductSaveAttempt(productName: String) {
+        analyticsRepository.logEvent(
+            Constants.Analytics.DishV2.NEW_PRODUCT_SAVE_ATTEMPT_FROM_DISH,
+            Bundle().apply {
+                putString(Constants.Analytics.PRODUCT_NAME, productName)
+            })
+    }
+
+    fun logNewProductSaveSuccess(newlyCreatedProduct: ProductDomain) {
+        analyticsRepository.logEvent(
+            Constants.Analytics.DishV2.NEW_PRODUCT_SAVE_SUCCESS_FROM_DISH,
+            Bundle().apply {
+                putString(Constants.Analytics.PRODUCT_NAME, newlyCreatedProduct.name)
+            })
+
+        analyticsRepository.logEvent(
+            Constants.Analytics.DishV2.PRODUCT_CREATED,
+            Bundle().apply {
+                putString(Constants.Analytics.PRODUCT_NAME, newlyCreatedProduct.name)
+                putString(Constants.Analytics.PRODUCT_UNIT, newlyCreatedProduct.unit)
+                putDouble(Constants.Analytics.PRODUCT_WASTE, newlyCreatedProduct.waste)
+                putDouble(
+                    Constants.Analytics.PRODUCT_PRICE_PER_UNIT,
+                    newlyCreatedProduct.pricePerUnit
+                )
+            })
+    }
+
+    fun logNewProductSaveFailure(productName: String) {
+        analyticsRepository.logEvent(
+            Constants.Analytics.DishV2.NEW_PRODUCT_SAVE_FAILURE_FROM_DISH,
+            Bundle().apply {
+                putString(Constants.Analytics.PRODUCT_NAME, productName)
+            })
+    }
+
+    fun logProductAddedToDishList(productName: String, selectedSuggestedProduct: ProductDomain?, quantityAddedToDish: Double, unit: String){
+        analyticsRepository.logEvent(
+            Constants.Analytics.DishV2.DISH_INGREDIENT_ADDED,
+            Bundle().apply {
+                putString(Constants.Analytics.DishV2.DISH_INGREDIENT_NAME, productName)
+                putString(
+                    Constants.Analytics.DishV2.DISH_INGREDIENT_TYPE,
+                    if (selectedSuggestedProduct == null) "new_in_context" else "existing"
+                )
+                putDouble(Constants.Analytics.DishV2.DISH_INGREDIENT_QUANTITY, quantityAddedToDish)
+                putString(Constants.Analytics.DishV2.DISH_INGREDIENT_UNIT, unit)
+            })
+    }
+
+    fun logHandleError(throwable: Throwable, errorResId: Int) {
+        analyticsRepository.logEvent(
+            Constants.Analytics.DishV2.ERROR_DISPLAYED_USER,
+            Bundle().apply {
+                putString(Constants.Analytics.DishV2.ERROR_TYPE, throwable::class.java.simpleName)
+                putInt(Constants.Analytics.DishV2.ERROR_MESSAGE_RES_ID, errorResId)
+            })
+    }
+
+    fun logDishSaveFailureAnalytics(dishName: String) {
+        analyticsRepository.logEvent(
+            Constants.Analytics.DishV2.DISH_SAVE_FAILURE,
+            Bundle().apply {
+                putString(Constants.Analytics.DISH_NAME, dishName)
+            })
+    }
+
+    fun logDishSaveSuccess(dishName: String, addedProductsSize: Int) {
+        analyticsRepository.logEvent(
+            Constants.Analytics.DishV2.DISH_SAVE_SUCCESS,
+            Bundle().apply {
+                putString(Constants.Analytics.DISH_NAME, dishName)
+                putInt(
+                    Constants.Analytics.DishV2.NUMBER_OF_INGREDIENTS,
+                    addedProductsSize
+                )
+            })
+        analyticsRepository.logEvent(Constants.Analytics.DISH_CREATED, Bundle().apply {
+            putString(Constants.Analytics.DISH_NAME, dishName)
+        })
+    }
+
+    fun logDishSaveAttempt(
+        dishName: String,
+        marginPercentInput: String,
+        taxPercentInput: String,
+        addedProductsSize: Int
+    ) {
+        analyticsRepository.logEvent(Constants.Analytics.DishV2.DISH_SAVE_ATTEMPT, Bundle().apply {
+            putString(Constants.Analytics.DISH_NAME, dishName)
+            putInt(Constants.Analytics.DishV2.NUMBER_OF_INGREDIENTS, addedProductsSize)
+            putString(Constants.Analytics.DishV2.DISH_MARGIN, marginPercentInput)
+            putString(Constants.Analytics.DishV2.DISH_TAX, taxPercentInput)
+        })
+    }
+
+    fun logSuggestionSelected(productName: String){
+        analyticsRepository.logEvent(
+            Constants.Analytics.DishV2.SUGGESTION_SELECTED,
+            Bundle().apply {
+                putString(Constants.Analytics.PRODUCT_NAME, productName)
+            })
+    }
+
+    fun logSuggestionDismissed(){
+        analyticsRepository.logEvent(
+            Constants.Analytics.DishV2.SUGGESTIONS_MANUALLY_DISMISSED,
+            null
+        )
+    }
+
+    fun logAddIngredientClick(productToAdd: ProductDomain?){
+        val bundle = Bundle()
+        if (productToAdd == null){
+            bundle.putString(Constants.Analytics.DishV2.ADD_INGREDIENT_TYPE_INTENT, "new_product")
+        } else {
+            bundle.putString(Constants.Analytics.DishV2.ADD_INGREDIENT_TYPE_INTENT, "existing_product")
+        }
+        analyticsRepository.logEvent(Constants.Analytics.DishV2.ADD_INGREDIENT_CLICKED, bundle)
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/SingleServing.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/SingleServing.kt
@@ -1,0 +1,3 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2
+
+const val SingleServing = 1.0

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishIntent.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishIntent.kt
@@ -1,0 +1,8 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart
+
+import com.erdees.foodcostcalc.domain.model.product.ProductDomain
+
+sealed class CreateDishIntent {
+    data class AddNewProduct(val productName: String) : CreateDishIntent()
+    data class AddProduct(val product: ProductDomain) : CreateDishIntent()
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishStartScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishStartScreen.kt
@@ -67,11 +67,13 @@ import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.SingleServing
 import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.existingProductForm.ExistingProductForm
 import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.existingProductForm.ExistingProductFormViewModel
 import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.newProductForm.NewProductForm
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.newProductForm.NewProductFormState
 import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.newProductForm.NewProductFormViewModel
 import com.erdees.foodcostcalc.ui.theme.FCCTheme
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 
+private const val MaxSuggestedProducts = 3
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -151,20 +153,22 @@ fun CreateDishStartScreen(
                     }, sheetState = newProductFormSheetState
                 ) {
                     NewProductForm(
-                        productName = newProductName,
-                        dishName = dishName,
-                        productCreationUnits = newProductFormViewModel.productCreationUnits.collectAsState().value,
-                        productAdditionUnits = newProductFormViewModel.productAdditionUnits.collectAsState().value,
-                        formData = newProductFormViewModel.formData.collectAsState().value,
-                        isAddButtonEnabled = newProductFormViewModel.isAddButtonEnabled.collectAsState().value,
-                        productCreationDropdownExpanded = newProductFormViewModel.productCreationUnitDropdownExpanded.collectAsState().value,
+                        NewProductFormState(
+                            productName = newProductName,
+                            dishName = dishName,
+                            productCreationUnits = newProductFormViewModel.productCreationUnits.collectAsState().value,
+                            productAdditionUnits = newProductFormViewModel.productAdditionUnits.collectAsState().value,
+                            formData = newProductFormViewModel.formData.collectAsState().value,
+                            isAddButtonEnabled = newProductFormViewModel.isAddButtonEnabled.collectAsState().value,
+                            productCreationDropdownExpanded = newProductFormViewModel.productCreationUnitDropdownExpanded.collectAsState().value,
+                            productAdditionDropdownExpanded = newProductFormViewModel.productAdditionUnitDropdownExpanded.collectAsState().value,
+                            ),
                         onProductCreationDropdownExpandedChange = {
                             newProductFormViewModel.productCreationUnitDropdownExpanded.value = it
                         },
                         onProductAdditionDropdownExpandedChange = {
                             newProductFormViewModel.productAdditionUnitDropdownExpanded.value = it
                         },
-                        productAdditionDropdownExpanded = newProductFormViewModel.productAdditionUnitDropdownExpanded.collectAsState().value,
                         onFormDataUpdate = newProductFormViewModel::updateFormData,
                         onSaveProduct = { data ->
                             scope.launch {
@@ -304,9 +308,9 @@ private fun CreateDishStartScreenContent(
                             value = newProductName,
                             placeholder = stringResource(R.string.product_name),
                             onValueChange = { updateNewProductName(it) },
-                            suggestions = suggestedProducts?.take(3) ?: emptyList(),
+                            suggestions = suggestedProducts?.take(MaxSuggestedProducts) ?: emptyList(),
                             shouldShowSuggestions = shouldShowSuggestedProducts,
-                            onSuggestionSelected = {
+                            onSuggestionSelect = {
                                 onSuggestedProductClick(it)
                             },
                             onDismissSuggestions = {
@@ -371,6 +375,7 @@ private fun CreateDishStartScreenContent(
     }
 }
 
+@Suppress("MagicNumber")
 @Preview
 @Composable
 private fun CreateDishStartScreenContentPreview() {

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishStartScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishStartScreen.kt
@@ -1,0 +1,319 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart
+
+import android.icu.util.Currency
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.sharp.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.erdees.foodcostcalc.R
+import com.erdees.foodcostcalc.domain.model.product.ProductAddedToDish
+import com.erdees.foodcostcalc.domain.model.product.ProductDomain
+import com.erdees.foodcostcalc.ui.composables.Ingredients
+import com.erdees.foodcostcalc.ui.composables.Section
+import com.erdees.foodcostcalc.ui.composables.buttons.FCCPrimaryButton
+import com.erdees.foodcostcalc.ui.composables.fields.FCCTextField
+import com.erdees.foodcostcalc.ui.composables.fields.FCCTextFieldWithSuggestions
+import com.erdees.foodcostcalc.ui.composables.labels.SectionLabel
+import com.erdees.foodcostcalc.ui.composables.rows.ButtonRow
+import com.erdees.foodcostcalc.ui.navigation.FCCScreen
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.CreateDishV2ViewModel
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.SingleServing
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.existingProductForm.ExistingProductForm
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.existingProductForm.ExistingProductFormViewModel
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.newProductForm.NewProductForm
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.newProductForm.NewProductFormViewModel
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateDishStartScreen(
+    navController: NavController,
+    viewModel: CreateDishV2ViewModel = viewModel(),
+    newProductFormViewModel: NewProductFormViewModel = viewModel(),
+    existingProductFormViewModel: ExistingProductFormViewModel = viewModel(),
+) {
+
+    val dishName by viewModel.dishName.collectAsState()
+    val newProductName by viewModel.newProductName.collectAsState()
+    val addedProducts by viewModel.addedProducts.collectAsState()
+    val suggestedProducts by viewModel.suggestedProducts.collectAsState()
+    val selectedProduct by viewModel.selectedSuggestedProduct.collectAsState()
+    val currency by viewModel.currency.collectAsState()
+    val shouldShowSuggestedProducts by viewModel.shouldShowSuggestedProducts.collectAsState()
+    val userIntent by viewModel.intent.collectAsState()
+
+    val newProductFormSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val existingProductFormSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        newProductFormViewModel.getProductCreationUnits(context.resources)
+    }
+
+    LaunchedEffect(selectedProduct) {
+        selectedProduct?.let {
+            existingProductFormViewModel.setProductContext(it, context.resources)
+        }
+    }
+
+    CreateDishStartScreenContent(
+        navController,
+        CreateDishStartScreenState(
+            dishName,
+            newProductName,
+            shouldShowSuggestedProducts,
+            addedProducts,
+            suggestedProducts,
+            selectedProduct,
+            currency
+        ),
+        viewModel::updateDishName,
+        viewModel::updateNewProductName,
+        viewModel::onAddIngredientClick,
+        viewModel::onSuggestionSelected,
+        viewModel::onSuggestionsManuallyDismissed,
+        onContinueClick = {
+            navController.navigate(FCCScreen.CreateDishSummary)
+        }
+    )
+
+    AnimatedVisibility(userIntent != null) {
+        when (userIntent) {
+            is CreateDishIntent.AddNewProduct -> {
+                ModalBottomSheet(
+                    onDismissRequest = {
+                        viewModel.onModalDismissed()
+                    },
+                    sheetState = newProductFormSheetState
+                ) {
+                    NewProductForm(
+                        productName = newProductName,
+                        dishName = dishName,
+                        productCreationUnits = newProductFormViewModel.productCreationUnits.collectAsState().value,
+                        productAdditionUnits = newProductFormViewModel.productAdditionUnits.collectAsState().value,
+                        formData = newProductFormViewModel.formData.collectAsState().value,
+                        isAddButtonEnabled = newProductFormViewModel.isAddButtonEnabled.collectAsState().value,
+                        productCreationDropdownExpanded = newProductFormViewModel.productCreationUnitDropdownExpanded.collectAsState().value,
+                        onProductCreationDropdownExpandedChange = {
+                            newProductFormViewModel.productCreationUnitDropdownExpanded.value = it
+                        },
+                        onProductAdditionDropdownExpandedChange = {
+                            newProductFormViewModel.productAdditionUnitDropdownExpanded.value = it
+                        },
+                        productAdditionDropdownExpanded = newProductFormViewModel.productAdditionUnitDropdownExpanded.collectAsState().value,
+                        onFormDataUpdate = newProductFormViewModel::updateFormData,
+                        onSaveProduct = {
+                            viewModel.onAddNewProductClick(it)
+                            newProductFormViewModel.onAddIngredientClick()
+                        },
+                    )
+                }
+            }
+
+            is CreateDishIntent.AddProduct -> {
+                ModalBottomSheet(
+                    onDismissRequest = {
+                        viewModel.onModalDismissed()
+                    },
+                    sheetState = existingProductFormSheetState
+                ) {
+                    ExistingProductForm(
+                        formData = existingProductFormViewModel.formData.collectAsState().value,
+                        isAddButtonEnabled = existingProductFormViewModel.isAddButtonEnabled.collectAsState().value,
+                        compatibleUnitsForDish = existingProductFormViewModel.compatibleUnitsForDish.collectAsState().value,
+                        unitForDishDropdownExpanded = existingProductFormViewModel.unitForDishDropdownExpanded.collectAsState().value,
+                        selectedProduct = (userIntent as CreateDishIntent.AddProduct).product,
+                        dishName = dishName,
+                        onFormDataChange = existingProductFormViewModel::updateFormData,
+                        onUnitForDishDropdownExpandedChange = {
+                            existingProductFormViewModel.unitForDishDropdownExpanded.value = it
+                        },
+                        onSaveIngredient = {
+                            viewModel.onAddExistingProductClick(it)
+                            existingProductFormViewModel.onAddIngredientClick()
+                        },
+                        onDismiss = {
+                            viewModel.onModalDismissed()
+                        }
+
+                    )
+                }
+            }
+
+            else -> {}
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CreateDishStartScreenContent(
+    navController: NavController,
+    createDishStartScreenState: CreateDishStartScreenState,
+    updateDishName: (String) -> Unit,
+    updateNewProductName: (String) -> Unit,
+    onAddIngredientClick: () -> Unit,
+    onSuggestedProductClick: (ProductDomain) -> Unit,
+    onDismissSuggestions: () -> Unit,
+    onContinueClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val dishNameFocusRequester = remember { FocusRequester() }
+    with(createDishStartScreenState) {
+        Scaffold(
+            modifier = modifier,
+            topBar = {
+                TopAppBar(
+                    title = { Text(text = stringResource(id = R.string.price_your_first_dish)) },
+                    navigationIcon = {
+                        IconButton(onClick = { navController.popBackStack() }) {
+                            Icon(
+                                Icons.AutoMirrored.Sharp.ArrowBack,
+                                contentDescription = stringResource(
+                                    id = R.string.back
+                                )
+                            )
+                        }
+                    })
+            }
+        ) { paddingValues ->
+            Column(
+                verticalArrangement = Arrangement.SpaceBetween,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(paddingValues)
+            ) {
+
+                Column(Modifier.padding(horizontal = 12.dp)) {
+                    FCCTextField(
+                        modifier = Modifier.focusRequester(dishNameFocusRequester),
+                        title = stringResource(R.string.dish_name),
+                        value = dishName,
+                        onValueChange = { updateDishName(it) },
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Text,
+                            capitalization = KeyboardCapitalization.Words,
+                            imeAction = ImeAction.Next
+                        )
+                    )
+
+                    Spacer(Modifier.size(24.dp))
+                    Text(
+                        if (addedProducts.isEmpty()) stringResource(R.string.add_first_ingredient) else stringResource(
+                            R.string.add_next_ingredient
+                        ),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+
+                    FCCTextFieldWithSuggestions(
+                        title = stringResource(R.string.product_name),
+                        value = newProductName,
+                        onValueChange = { updateNewProductName(it) },
+                        suggestions = suggestedProducts?.take(3) ?: emptyList(),
+                        shouldShowSuggestions = shouldShowSuggestedProducts,
+                        onSuggestionSelected = {
+                            onSuggestedProductClick(it)
+                        },
+                        onDismissSuggestions = {
+                            onDismissSuggestions()
+                        },
+                        suggestionItemContent = { product ->
+                            Text(text = product.name, modifier = Modifier.padding(8.dp))
+                        },
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Text,
+                            capitalization = KeyboardCapitalization.Words,
+                            imeAction = ImeAction.Next
+                        )
+                    )
+
+                    ButtonRow(
+                        primaryButton = {
+                            FCCPrimaryButton(
+                                stringResource(R.string.add_product),
+                                onClick = { onAddIngredientClick() }
+                            )
+                        }
+                    )
+                }
+
+                Section {
+                    SectionLabel(stringResource(R.string.added_ingredients))
+                    Ingredients(addedProducts, listOf(), SingleServing, currency)
+                    ButtonRow(
+                        applyDefaultPadding = false,
+                        primaryButton = {
+                            FCCPrimaryButton(stringResource(R.string.continue_dish_creation), onClick = {
+                                onContinueClick()
+                            })
+                        })
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CreateDishStartScreenContentPreview() {
+    CreateDishStartScreenContent(
+        navController = rememberNavController(),
+        createDishStartScreenState = CreateDishStartScreenState(
+            dishName = "Spaghetti Bolognese",
+            newProductName = "",
+            shouldShowSuggestedProducts = false,
+            addedProducts = listOf(
+                ProductAddedToDish(
+                    ProductDomain(0L, "Tomato", 3.99, 0.0, 10.0, "kg"),
+                    0.5,
+                    "kg",
+                )
+            ),
+            currency = Currency.getInstance("PLN")
+        ),
+        updateDishName = {},
+        updateNewProductName = {},
+        onAddIngredientClick = {},
+        onContinueClick = {},
+        onSuggestedProductClick = {},
+        onDismissSuggestions = {})
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishStartScreenState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishStartScreenState.kt
@@ -1,6 +1,7 @@
 package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart
 
 import android.icu.util.Currency
+import androidx.annotation.StringRes
 import com.erdees.foodcostcalc.domain.model.product.ProductAddedToDish
 import com.erdees.foodcostcalc.domain.model.product.ProductDomain
 
@@ -12,5 +13,6 @@ data class CreateDishStartScreenState(
     val suggestedProducts: List<ProductDomain>? = listOf(),
     val selectedSuggestedProduct: ProductDomain? = null,
     val currency: Currency?,
-    val isFirstDish: Boolean
+    val isFirstDish: Boolean,
+    @StringRes val errorRes: Int?,
 )

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishStartScreenState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishStartScreenState.kt
@@ -12,5 +12,5 @@ data class CreateDishStartScreenState(
     val suggestedProducts: List<ProductDomain>? = listOf(),
     val selectedSuggestedProduct: ProductDomain? = null,
     val currency: Currency?,
-    val operation: CreateDishIntent? = null
+    val isFirstDish: Boolean
 )

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishStartScreenState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/CreateDishStartScreenState.kt
@@ -1,0 +1,16 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart
+
+import android.icu.util.Currency
+import com.erdees.foodcostcalc.domain.model.product.ProductAddedToDish
+import com.erdees.foodcostcalc.domain.model.product.ProductDomain
+
+data class CreateDishStartScreenState(
+    val dishName: String,
+    val newProductName: String,
+    val shouldShowSuggestedProducts: Boolean,
+    val addedProducts: List<ProductAddedToDish> = listOf(),
+    val suggestedProducts: List<ProductDomain>? = listOf(),
+    val selectedSuggestedProduct: ProductDomain? = null,
+    val currency: Currency?,
+    val operation: CreateDishIntent? = null
+)

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/existingProductForm/ExistingProductForm.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/existingProductForm/ExistingProductForm.kt
@@ -110,6 +110,8 @@ fun ExistingProductForm(
         Spacer(modifier = Modifier.height(16.dp))
 
         ButtonRow(
+            modifier = Modifier.padding(vertical = 12.dp),
+            applyDefaultPadding = false,
             primaryButton = {
                 FCCPrimaryButton(
                     text = "Add Ingredient",

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/existingProductForm/ExistingProductForm.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/existingProductForm/ExistingProductForm.kt
@@ -1,0 +1,151 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.existingProductForm // Or a more general location
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.erdees.foodcostcalc.domain.model.product.ProductDomain
+import com.erdees.foodcostcalc.ui.composables.buttons.FCCPrimaryButton
+import com.erdees.foodcostcalc.ui.composables.buttons.FCCTextButton
+import com.erdees.foodcostcalc.ui.composables.fields.FCCTextField
+import com.erdees.foodcostcalc.ui.composables.fields.UnitField
+import com.erdees.foodcostcalc.ui.composables.rows.ButtonRow
+import com.erdees.foodcostcalc.ui.theme.FCCTheme
+import com.erdees.foodcostcalc.utils.onNumericValueChange
+
+
+@Composable
+fun ExistingProductForm(
+    formData: ExistingProductFormData,
+    isAddButtonEnabled: Boolean,
+    compatibleUnitsForDish: Set<String>,
+    unitForDishDropdownExpanded: Boolean,
+    selectedProduct: ProductDomain,
+    dishName: String,
+    onFormDataChange: (ExistingProductFormData) -> Unit, // More generic callback for form data changes
+    onUnitForDishDropdownExpandedChange: (Boolean) -> Unit,
+    onSaveIngredient: (ExistingProductFormData) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val quantityFocusRequester = remember { FocusRequester() }
+    val unitForDishFocusRequester = remember { FocusRequester() }
+    val scrollState = rememberScrollState()
+    val localFocusManager = LocalFocusManager.current
+
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+            .verticalScroll(scrollState),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "Add Ingredient: ${selectedProduct.name}",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        FCCTextField(
+            modifier = Modifier.focusRequester(quantityFocusRequester),
+            title = "Quantity for '$dishName'",
+            value = formData.quantityForDish,
+            onValueChange = { newValue ->
+                onFormDataChange(
+                    formData.copy(
+                        quantityForDish = onNumericValueChange(
+                            formData.quantityForDish,
+                            newValue
+                        )
+                    )
+                )
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Decimal,
+                imeAction = ImeAction.Next
+            ),
+            keyboardActions = KeyboardActions(
+                onNext = {
+                    unitForDishFocusRequester.requestFocus()
+                    onUnitForDishDropdownExpandedChange(true)
+                }
+            )
+        )
+
+        UnitField(
+            modifier = Modifier.focusRequester(unitForDishFocusRequester),
+            label = "Unit for dish",
+            units = compatibleUnitsForDish,
+            expanded = unitForDishDropdownExpanded,
+            onExpandChange = { isExpanded -> onUnitForDishDropdownExpandedChange(isExpanded) },
+            selectedUnit = formData.unitForDish,
+            selectUnit = { selectedUnit ->
+                onFormDataChange(formData.copy(unitForDish = selectedUnit))
+                // Optionally hide keyboard or move focus
+                onUnitForDishDropdownExpandedChange(false) // Close dropdown after selection
+                localFocusManager.clearFocus() // Example: Clear focus after selection
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ButtonRow(
+            primaryButton = {
+                FCCPrimaryButton(
+                    text = "Add Ingredient",
+                    enabled = isAddButtonEnabled,
+                    onClick = { onSaveIngredient(formData) }
+                )
+            },
+            secondaryButton = {
+                FCCTextButton(
+                    text = "Cancel",
+                    onClick = onDismiss
+                )
+            }
+        )
+    }
+}
+
+
+@Preview(showBackground = true, name = "Existing Product Form - Light")
+@PreviewLightDark
+@Composable
+private fun ExistingProductIngredientFormPreview() {
+    val previewProduct = ProductDomain(
+        id = 1L, name = "Flour", pricePerUnit = 2.5, tax = 0.0, unit = "kg", waste = 10.0
+    )
+    FCCTheme {
+        ExistingProductForm(
+            formData = ExistingProductFormData(quantityForDish = "100", unitForDish = "g"),
+            isAddButtonEnabled = true,
+            compatibleUnitsForDish = setOf("g", "kg", "oz", "lb"),
+            unitForDishDropdownExpanded = false,
+            selectedProduct = previewProduct,
+            dishName = "Bread",
+            onFormDataChange = {},
+            onDismiss = {},
+            onSaveIngredient = {},
+            onUnitForDishDropdownExpandedChange = {})
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/existingProductForm/ExistingProductForm.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/existingProductForm/ExistingProductForm.kt
@@ -42,9 +42,10 @@ fun ExistingProductForm(
     unitForDishDropdownExpanded: Boolean,
     selectedProduct: ProductDomain,
     dishName: String,
-    onFormDataChange: (ExistingProductFormData) -> Unit, // More generic callback for form data changes
-    onUnitForDishDropdownExpandedChange: (Boolean) -> Unit,
-    onSaveIngredient: (ExistingProductFormData) -> Unit,
+    modifier: Modifier = Modifier,
+    onFormDataChange: (ExistingProductFormData) -> Unit = {},
+    onUnitForDishDropdownExpandedChange: (Boolean) -> Unit = {},
+    onSaveIngredient: (ExistingProductFormData) -> Unit = {},
     onDismiss: () -> Unit,
 ) {
     val quantityFocusRequester = remember { FocusRequester() }
@@ -53,7 +54,7 @@ fun ExistingProductForm(
     val localFocusManager = LocalFocusManager.current
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .padding(16.dp)
             .fillMaxWidth()
             .verticalScroll(scrollState),

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/existingProductForm/ExistingProductFormData.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/existingProductForm/ExistingProductFormData.kt
@@ -1,0 +1,6 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.existingProductForm
+
+data class ExistingProductFormData(
+    val quantityForDish: String = "",
+    val unitForDish: String = ""
+)

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/existingProductForm/ExistingProductFormViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/existingProductForm/ExistingProductFormViewModel.kt
@@ -1,0 +1,84 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.existingProductForm
+
+import android.content.res.Resources
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.erdees.foodcostcalc.data.Preferences
+import com.erdees.foodcostcalc.domain.model.product.ProductDomain
+import com.erdees.foodcostcalc.utils.UnitsUtils
+import com.erdees.foodcostcalc.utils.Utils
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class ExistingProductFormViewModel : ViewModel(), KoinComponent {
+
+    private val preferences: Preferences by inject()
+
+    // To control the dropdown for "unit for dish"
+    val unitForDishDropdownExpanded = MutableStateFlow(false)
+
+    private val _formData = MutableStateFlow(ExistingProductFormData())
+    val formData: StateFlow<ExistingProductFormData> = _formData
+
+    // Enable button if quantity is a valid number and a unit is selected
+    val isAddButtonEnabled = formData.map {
+        it.quantityForDish.toDoubleOrNull() != null && it.unitForDish.isNotEmpty()
+    }.stateIn(viewModelScope, SharingStarted.Lazily, false)
+
+    fun updateFormData(newValue: ExistingProductFormData) {
+        _formData.update { newValue }
+    }
+
+    // This will hold the units compatible with the selected product's base unit
+    val compatibleUnitsForDish = MutableStateFlow<Set<String>>(emptySet())
+
+    /**
+     * Populates the compatible units for the dish based on the selected product's primary unit.
+     * This should be called when the form is initialized with a selected product.
+     */
+    fun setProductContext(product: ProductDomain, resources: Resources) {
+        viewModelScope.launch {
+            // Determine the unit type from the product's own unit (e.g., if product is in "kg", show "g", "kg", "oz", "lb")
+            // This assumes ProductDomain has a field like 'unit' or 'purchaseUnit'
+            val productBaseUnit = product.unit // Or product.purchaseUnit, product.mainUnit etc.
+            val unitType = UnitsUtils.getUnitType(productBaseUnit)
+
+            if (unitType != null) {
+                val metricUsed = preferences.metricUsed.first()
+                val imperialUsed = preferences.imperialUsed.first()
+                val units = Utils.generateUnitSet(unitType, metricUsed, imperialUsed)
+                compatibleUnitsForDish.value = units
+
+                // Set a default unit if current selection is empty and units are available
+                if (_formData.value.unitForDish.isEmpty() && units.isNotEmpty()) {
+                    _formData.update { it.copy(unitForDish = units.first()) }
+                }
+            } else {
+                // Handle case where product base unit is unknown or not supported
+                // Maybe default to a generic set of units or leave it empty
+                compatibleUnitsForDish.value = Utils.getUnitsSet(resources, preferences.metricUsed.first(), preferences.imperialUsed.first()) // Fallback to all units
+                if (_formData.value.unitForDish.isEmpty() && compatibleUnitsForDish.value.isNotEmpty()){
+                    _formData.update { it.copy(unitForDish = compatibleUnitsForDish.value.first()) }
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Call this when the "Add Ingredient" button is clicked.
+     * It should probably return the form data to the calling screen/ViewModel.
+     */
+    fun onAddIngredientClick() {
+        _formData.value = ExistingProductFormData()
+        unitForDishDropdownExpanded.value = false
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/newProductForm/NewProductForm.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/newProductForm/NewProductForm.kt
@@ -1,0 +1,174 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.newProductForm
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.erdees.foodcostcalc.ui.composables.buttons.FCCPrimaryButton
+import com.erdees.foodcostcalc.ui.composables.fields.FCCTextField
+import com.erdees.foodcostcalc.ui.composables.fields.UnitField
+import com.erdees.foodcostcalc.ui.composables.rows.ButtonRow
+import com.erdees.foodcostcalc.ui.theme.FCCTheme
+import com.erdees.foodcostcalc.utils.onNumericValueChange
+
+@Composable
+fun NewProductForm(
+    productName: String,
+    dishName: String,
+    productCreationUnits: Set<String>,
+    productAdditionUnits: Set<String>,
+    formData: NewProductFormData,
+    isAddButtonEnabled: Boolean,
+    productCreationDropdownExpanded: Boolean,
+    onProductCreationDropdownExpandedChange: (Boolean) -> Unit,
+    productAdditionDropdownExpanded: Boolean,
+    onProductAdditionDropdownExpandedChange: (Boolean) -> Unit,
+    onFormDataUpdate: (NewProductFormData) -> Unit,
+    onSaveProduct: (NewProductFormData) -> Unit,
+) {
+    val purchaseUnitFocusRequester = remember { FocusRequester() }
+    val productAdditionUnitFocusRequester = remember { FocusRequester() }
+    val wastePercentFocusRequester = remember { FocusRequester() }
+    val scrollState = rememberScrollState()
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+            .verticalScroll(scrollState),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text("New Ingredient: $productName", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+
+        FCCTextField(
+            title = "Purchase Price",
+            value = formData.purchasePrice,
+            onValueChange = {
+                val newValue = onNumericValueChange(formData.purchasePrice, it)
+                onFormDataUpdate(formData.copy(purchasePrice = newValue))
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Decimal,
+                imeAction = ImeAction.Next
+            ),
+            keyboardActions = KeyboardActions(onNext = {
+                purchaseUnitFocusRequester.requestFocus()
+                onProductCreationDropdownExpandedChange(true)
+            })
+        )
+
+        UnitField(
+            modifier = Modifier.focusRequester(purchaseUnitFocusRequester),
+            label = "Purchase unit",
+            expanded = productCreationDropdownExpanded,
+            onExpandChange = { onProductCreationDropdownExpandedChange(it) },
+            units = productCreationUnits,
+            selectedUnit = formData.purchaseUnit,
+            selectUnit = {
+                onFormDataUpdate(formData.copy(purchaseUnit = it))
+                wastePercentFocusRequester.requestFocus()
+            }
+        )
+
+        // Waste %
+        FCCTextField(
+            modifier = Modifier.focusRequester(wastePercentFocusRequester),
+            value = formData.wastePercent,
+            title = "Waste % (Optional)",
+            onValueChange = {
+                val newValue = onNumericValueChange(formData.wastePercent, it)
+                onFormDataUpdate(formData.copy(wastePercent = newValue))
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Next
+            )
+        )
+
+        FCCTextField(
+            value = formData.quantityAddedToDish,
+            title = "Quantity for '$dishName'",
+            onValueChange = {
+                val newValue = onNumericValueChange(formData.quantityAddedToDish, it)
+                onFormDataUpdate(formData.copy(quantityAddedToDish = newValue))
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Decimal,
+                imeAction = ImeAction.Next
+            ),
+            keyboardActions = KeyboardActions(onNext = {
+                productAdditionUnitFocusRequester.requestFocus()
+                onProductAdditionDropdownExpandedChange(true)
+            })
+        )
+
+        UnitField(
+            modifier = Modifier.focusRequester(productAdditionUnitFocusRequester),
+            label = "Unit for dish",
+            units = productAdditionUnits,
+            expanded = productAdditionDropdownExpanded,
+            onExpandChange = { onProductAdditionDropdownExpandedChange(it) },
+            selectedUnit = formData.unitForDish,
+            selectUnit = {
+                onFormDataUpdate(formData.copy(unitForDish = it))
+            })
+
+        ButtonRow(
+            primaryButton = {
+                FCCPrimaryButton("Add Ingredient", enabled = isAddButtonEnabled) {
+                    onSaveProduct(formData)
+                }
+            }
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "New Product Form")
+@PreviewLightDark
+@Composable
+private fun NewProductIngredientModalContentDarkPreview() {
+    FCCTheme {
+        NewProductForm(
+            productName = "Sugar",
+            dishName = "Cake",
+            onSaveProduct = {
+                println("Preview (Dark): Add Ingredient Clicked with data:")
+            },
+            productAdditionUnits = setOf("kg", "g", "l", "ml"),
+            productCreationUnits = setOf("per kilogram", "per liter"),
+            productAdditionDropdownExpanded = false,
+            productCreationDropdownExpanded = false,
+            onProductAdditionDropdownExpandedChange = {},
+            onProductCreationDropdownExpandedChange = {},
+            isAddButtonEnabled = true,
+            onFormDataUpdate = {},
+            formData = NewProductFormData(
+                purchasePrice = "12.99",
+                purchaseUnit = "per kilogram",
+                "10",
+                "200",
+                "gram"
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/newProductForm/NewProductForm.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/newProductForm/NewProductForm.kt
@@ -134,6 +134,8 @@ fun NewProductForm(
             })
 
         ButtonRow(
+            modifier = Modifier.padding(vertical = 12.dp),
+            applyDefaultPadding = false,
             primaryButton = {
                 FCCPrimaryButton("Add Ingredient", enabled = isAddButtonEnabled) {
                     onSaveProduct(formData)

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/newProductForm/NewProductForm.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/newProductForm/NewProductForm.kt
@@ -29,119 +29,125 @@ import com.erdees.foodcostcalc.ui.composables.fields.UnitField
 import com.erdees.foodcostcalc.ui.composables.rows.ButtonRow
 import com.erdees.foodcostcalc.ui.theme.FCCTheme
 import com.erdees.foodcostcalc.utils.onNumericValueChange
+data class NewProductFormState(
+    val productName: String,
+    val dishName: String,
+    val productCreationUnits: Set<String>,
+    val productAdditionUnits: Set<String>,
+    val formData: NewProductFormData,
+    val isAddButtonEnabled: Boolean,
+    val productCreationDropdownExpanded: Boolean,
+    val productAdditionDropdownExpanded: Boolean,
+)
 
 @Composable
 fun NewProductForm(
-    productName: String,
-    dishName: String,
-    productCreationUnits: Set<String>,
-    productAdditionUnits: Set<String>,
-    formData: NewProductFormData,
-    isAddButtonEnabled: Boolean,
-    productCreationDropdownExpanded: Boolean,
-    onProductCreationDropdownExpandedChange: (Boolean) -> Unit,
-    productAdditionDropdownExpanded: Boolean,
-    onProductAdditionDropdownExpandedChange: (Boolean) -> Unit,
-    onFormDataUpdate: (NewProductFormData) -> Unit,
-    onSaveProduct: (NewProductFormData) -> Unit,
+    state: NewProductFormState,
+    modifier: Modifier = Modifier,
+    onProductCreationDropdownExpandedChange: (Boolean) -> Unit = {},
+    onProductAdditionDropdownExpandedChange: (Boolean) -> Unit = {},
+    onFormDataUpdate: (NewProductFormData) -> Unit = {},
+    onSaveProduct: (NewProductFormData) -> Unit = {},
 ) {
     val purchaseUnitFocusRequester = remember { FocusRequester() }
     val productAdditionUnitFocusRequester = remember { FocusRequester() }
     val wastePercentFocusRequester = remember { FocusRequester() }
     val scrollState = rememberScrollState()
-    Column(
-        modifier = Modifier
-            .padding(16.dp)
-            .fillMaxWidth()
-            .verticalScroll(scrollState),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        Text("New Ingredient: $productName", style = MaterialTheme.typography.titleMedium)
-        Spacer(modifier = Modifier.height(8.dp))
+    with(state) {
+        Column(
+            modifier = modifier
+                .padding(16.dp)
+                .fillMaxWidth()
+                .verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("New Ingredient: $productName", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
 
-        FCCTextField(
-            title = "Purchase Price",
-            value = formData.purchasePrice,
-            onValueChange = {
-                val newValue = onNumericValueChange(formData.purchasePrice, it)
-                onFormDataUpdate(formData.copy(purchasePrice = newValue))
-            },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Decimal,
-                imeAction = ImeAction.Next
-            ),
-            keyboardActions = KeyboardActions(onNext = {
-                purchaseUnitFocusRequester.requestFocus()
-                onProductCreationDropdownExpandedChange(true)
-            })
-        )
-
-        UnitField(
-            modifier = Modifier.focusRequester(purchaseUnitFocusRequester),
-            label = "Purchase unit",
-            expanded = productCreationDropdownExpanded,
-            onExpandChange = { onProductCreationDropdownExpandedChange(it) },
-            units = productCreationUnits,
-            selectedUnit = formData.purchaseUnit,
-            selectUnit = {
-                onFormDataUpdate(formData.copy(purchaseUnit = it))
-                wastePercentFocusRequester.requestFocus()
-            }
-        )
-
-        // Waste %
-        FCCTextField(
-            modifier = Modifier.focusRequester(wastePercentFocusRequester),
-            value = formData.wastePercent,
-            title = "Waste % (Optional)",
-            onValueChange = {
-                val newValue = onNumericValueChange(formData.wastePercent, it)
-                onFormDataUpdate(formData.copy(wastePercent = newValue))
-            },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number,
-                imeAction = ImeAction.Next
+            FCCTextField(
+                title = "Purchase Price",
+                value = formData.purchasePrice,
+                onValueChange = {
+                    val newValue = onNumericValueChange(formData.purchasePrice, it)
+                    onFormDataUpdate(formData.copy(purchasePrice = newValue))
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Decimal,
+                    imeAction = ImeAction.Next
+                ),
+                keyboardActions = KeyboardActions(onNext = {
+                    purchaseUnitFocusRequester.requestFocus()
+                    onProductCreationDropdownExpandedChange(true)
+                })
             )
-        )
 
-        FCCTextField(
-            value = formData.quantityAddedToDish,
-            title = "Quantity for '$dishName'",
-            onValueChange = {
-                val newValue = onNumericValueChange(formData.quantityAddedToDish, it)
-                onFormDataUpdate(formData.copy(quantityAddedToDish = newValue))
-            },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Decimal,
-                imeAction = ImeAction.Next
-            ),
-            keyboardActions = KeyboardActions(onNext = {
-                productAdditionUnitFocusRequester.requestFocus()
-                onProductAdditionDropdownExpandedChange(true)
-            })
-        )
-
-        UnitField(
-            modifier = Modifier.focusRequester(productAdditionUnitFocusRequester),
-            label = "Unit for dish",
-            units = productAdditionUnits,
-            expanded = productAdditionDropdownExpanded,
-            onExpandChange = { onProductAdditionDropdownExpandedChange(it) },
-            selectedUnit = formData.unitForDish,
-            selectUnit = {
-                onFormDataUpdate(formData.copy(unitForDish = it))
-            })
-
-        ButtonRow(
-            modifier = Modifier.padding(vertical = 12.dp),
-            applyDefaultPadding = false,
-            primaryButton = {
-                FCCPrimaryButton("Add Ingredient", enabled = isAddButtonEnabled) {
-                    onSaveProduct(formData)
+            UnitField(
+                modifier = Modifier.focusRequester(purchaseUnitFocusRequester),
+                label = "Purchase unit",
+                expanded = productCreationDropdownExpanded,
+                onExpandChange = { onProductCreationDropdownExpandedChange(it) },
+                units = productCreationUnits,
+                selectedUnit = formData.purchaseUnit,
+                selectUnit = {
+                    onFormDataUpdate(formData.copy(purchaseUnit = it))
+                    wastePercentFocusRequester.requestFocus()
                 }
-            }
-        )
+            )
+
+            // Waste %
+            FCCTextField(
+                modifier = Modifier.focusRequester(wastePercentFocusRequester),
+                value = formData.wastePercent,
+                title = "Waste % (Optional)",
+                onValueChange = {
+                    val newValue = onNumericValueChange(formData.wastePercent, it)
+                    onFormDataUpdate(formData.copy(wastePercent = newValue))
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Next
+                )
+            )
+
+            FCCTextField(
+                value = formData.quantityAddedToDish,
+                title = "Quantity for '$dishName'",
+                onValueChange = {
+                    val newValue = onNumericValueChange(formData.quantityAddedToDish, it)
+                    onFormDataUpdate(formData.copy(quantityAddedToDish = newValue))
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Decimal,
+                    imeAction = ImeAction.Next
+                ),
+                keyboardActions = KeyboardActions(onNext = {
+                    productAdditionUnitFocusRequester.requestFocus()
+                    onProductAdditionDropdownExpandedChange(true)
+                })
+            )
+
+            UnitField(
+                modifier = Modifier.focusRequester(productAdditionUnitFocusRequester),
+                label = "Unit for dish",
+                units = productAdditionUnits,
+                expanded = productAdditionDropdownExpanded,
+                onExpandChange = { onProductAdditionDropdownExpandedChange(it) },
+                selectedUnit = formData.unitForDish,
+                selectUnit = {
+                    onFormDataUpdate(formData.copy(unitForDish = it))
+                })
+
+            ButtonRow(
+                modifier = Modifier.padding(vertical = 12.dp),
+                applyDefaultPadding = false,
+                primaryButton = {
+                    FCCPrimaryButton("Add Ingredient", enabled = isAddButtonEnabled) {
+                        onSaveProduct(formData)
+                    }
+                }
+            )
+        }
     }
 }
 
@@ -151,26 +157,28 @@ fun NewProductForm(
 private fun NewProductIngredientModalContentDarkPreview() {
     FCCTheme {
         NewProductForm(
-            productName = "Sugar",
-            dishName = "Cake",
+            NewProductFormState(
+                productName = "Sugar",
+                dishName = "Cake",
+                productAdditionUnits = setOf("kg", "g", "l", "ml"),
+                productCreationUnits = setOf("per kilogram", "per liter"),
+                productAdditionDropdownExpanded = false,
+                productCreationDropdownExpanded = false,
+                formData = NewProductFormData(
+                    purchasePrice = "12.99",
+                    purchaseUnit = "per kilogram",
+                    "10",
+                    "200",
+                    "gram"
+                ),
+                isAddButtonEnabled = true,
+            ),
             onSaveProduct = {
                 println("Preview (Dark): Add Ingredient Clicked with data:")
             },
-            productAdditionUnits = setOf("kg", "g", "l", "ml"),
-            productCreationUnits = setOf("per kilogram", "per liter"),
-            productAdditionDropdownExpanded = false,
-            productCreationDropdownExpanded = false,
             onProductAdditionDropdownExpandedChange = {},
             onProductCreationDropdownExpandedChange = {},
-            isAddButtonEnabled = true,
             onFormDataUpdate = {},
-            formData = NewProductFormData(
-                purchasePrice = "12.99",
-                purchaseUnit = "per kilogram",
-                "10",
-                "200",
-                "gram"
-            )
         )
     }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/newProductForm/NewProductFormData.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/newProductForm/NewProductFormData.kt
@@ -1,0 +1,9 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.newProductForm
+
+data class NewProductFormData(
+    val purchasePrice: String = "",
+    val purchaseUnit: String = "",
+    val wastePercent: String = "",
+    val quantityAddedToDish: String = "",
+    val unitForDish: String = ""
+)

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/newProductForm/NewProductFormViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishStart/newProductForm/NewProductFormViewModel.kt
@@ -1,0 +1,94 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishStart.newProductForm
+
+import android.content.res.Resources
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.erdees.foodcostcalc.data.Preferences
+import com.erdees.foodcostcalc.utils.UnitsUtils
+import com.erdees.foodcostcalc.utils.Utils
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class NewProductFormViewModel : ViewModel(), KoinComponent {
+
+    private val preferences: Preferences by inject()
+
+    val productCreationUnitDropdownExpanded: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val productAdditionUnitDropdownExpanded: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    private val _formData = MutableStateFlow(NewProductFormData())
+    val formData: StateFlow<NewProductFormData> = _formData
+
+    val isAddButtonEnabled = formData.map {
+        it.purchasePrice.toDoubleOrNull() != null &&
+                it.unitForDish.isNotEmpty() &&
+                it.purchaseUnit.isNotEmpty() &&
+                it.quantityAddedToDish.toDoubleOrNull() != null
+    }.stateIn(viewModelScope, SharingStarted.Lazily, false)
+
+    fun updateFormData(newValue: NewProductFormData) {
+        _formData.update { newValue }
+    }
+
+    val productCreationUnits = MutableStateFlow<Set<String>>(setOf())
+
+    val productAdditionUnits = formData
+        .distinctUntilChanged { old, new ->
+            old.purchaseUnit == new.purchaseUnit
+        }.map { formData ->
+            val unitType = UnitsUtils.getUnitType(formData.purchaseUnit)
+            unitType?.let { getUnitList(it) } ?: emptySet()
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
+
+    init {
+        viewModelScope.launch {
+            productAdditionUnits
+                .distinctUntilChanged(areEquivalent = { old, new -> old == new })
+                .filter { it.isNotEmpty() }
+                .collect { availableUnits ->
+                    if (formData.value.unitForDish.isEmpty()) {
+                        _formData.update { it.copy(unitForDish = availableUnits.first()) }
+                    }
+                }
+        }
+    }
+
+
+    /**
+     * Function used to prepare selection of units for the product creation.
+     * */
+    fun getProductCreationUnits(resources: Resources) {
+        viewModelScope.launch {
+            val metricUsed = preferences.metricUsed.first()
+            val imperialUsed = preferences.imperialUsed.first()
+            productCreationUnits.update { Utils.getUnitsSet(resources, metricUsed, imperialUsed) }
+        }
+    }
+
+    /** Function used to prepare selection of units for the product addition,
+     *  This is called every time product creation unit changes to provide relevant units in other dropdown.
+     * */
+    private suspend fun getUnitList(unitType: UnitsUtils.UnitType): Set<String> {
+        val metricUnits = preferences.metricUsed.first()
+        val imperialUnits = preferences.imperialUsed.first()
+        return Utils.generateUnitSet(
+            unitType,
+            metricUnits,
+            imperialUnits
+        )
+    }
+
+    fun onAddIngredientClick(){
+        _formData.value = NewProductFormData()
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
@@ -1,6 +1,9 @@
 package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishSummary
 
 import android.icu.util.Currency
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -27,7 +30,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,6 +60,7 @@ import com.erdees.foodcostcalc.ui.composables.buttons.FCCTextButton
 import com.erdees.foodcostcalc.ui.composables.dialogs.ErrorDialog
 import com.erdees.foodcostcalc.ui.composables.fields.FCCTextField
 import com.erdees.foodcostcalc.ui.composables.rows.ButtonRow
+import com.erdees.foodcostcalc.ui.navigation.FCCScreen
 import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.CreateDishV2ViewModel
 import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.SingleServing
 import com.erdees.foodcostcalc.ui.theme.FCCTheme
@@ -65,6 +71,19 @@ fun CreateDishSummaryScreen(
     navController: NavController,
     viewModel: CreateDishV2ViewModel,
 ) {
+    val successfullySavedDishId by viewModel.saveDishSuccess.collectAsState()
+
+    LaunchedEffect(successfullySavedDishId) {
+        successfullySavedDishId?.let {
+            navController.navigate(FCCScreen.EditDish(it)) {
+                popUpTo(FCCScreen.Dishes) {
+                    inclusive = false
+                }
+            }
+            viewModel.resetSaveDishSuccess()
+        }
+    }
+
     CreateDishSummaryContent(
         CreateDishSummaryScreenState(
             dishName = viewModel.dishName.collectAsState().value,
@@ -96,7 +115,7 @@ fun CreateDishSummaryContent(
     onErrorDismiss: () -> Unit = {}
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
-    val focusManager = LocalFocusManager.current // Get FocusManager instance
+    val focusManager = LocalFocusManager.current
     val interactionSource = remember { MutableInteractionSource() }
     Scaffold(
         topBar = {
@@ -120,8 +139,7 @@ fun CreateDishSummaryContent(
                 .padding(16.dp)
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
-                .imePadding()
-            ,
+                .imePadding(),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.SpaceBetween
         ) {
@@ -135,7 +153,10 @@ fun CreateDishSummaryContent(
             )
 
             CalculationCard(
-                modifier = Modifier.clickable(indication = null, interactionSource = interactionSource) {
+                modifier = Modifier.clickable(
+                    indication = null,
+                    interactionSource = interactionSource
+                ) {
                     keyboardController?.hide()
                     focusManager.clearFocus()
                 },
@@ -164,7 +185,7 @@ fun CreateDishSummaryContent(
                 },
             )
         }
-        if (state.isLoading) {
+        AnimatedVisibility(state.isLoading, enter = fadeIn(), exit = fadeOut()) {
             ScreenLoadingOverlay(Modifier.fillMaxSize())
         }
 

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
@@ -1,15 +1,17 @@
 package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishSummary
 
 import android.icu.util.Currency
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -26,8 +28,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -90,6 +95,9 @@ fun CreateDishSummaryContent(
     onTaxChange: (String) -> Unit = {},
     onErrorDismiss: () -> Unit = {}
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current // Get FocusManager instance
+    val interactionSource = remember { MutableInteractionSource() }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -111,7 +119,9 @@ fun CreateDishSummaryContent(
                 .padding(paddingValues)
                 .padding(16.dp)
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState()),
+                .verticalScroll(rememberScrollState())
+                .imePadding()
+            ,
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.SpaceBetween
         ) {
@@ -125,6 +135,10 @@ fun CreateDishSummaryContent(
             )
 
             CalculationCard(
+                modifier = Modifier.clickable(indication = null, interactionSource = interactionSource) {
+                    keyboardController?.hide()
+                    focusManager.clearFocus()
+                },
                 state = state,
                 onMarginChanged = { onMarginChange(it) },
                 onTaxChanged = { onTaxChange(it) }
@@ -166,11 +180,12 @@ fun CreateDishSummaryContent(
 @Composable
 fun CalculationCard(
     state: CreateDishSummaryScreenState,
+    modifier: Modifier = Modifier,
     onMarginChanged: (String) -> Unit,
     onTaxChanged: (String) -> Unit
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
         Column(
@@ -191,7 +206,7 @@ fun CalculationCard(
                         imeAction = ImeAction.Next
                     ),
                     singleLine = true,
-                    modifier = Modifier.width(150.dp)
+                    modifier = Modifier.weight(1f)
                 )
 
                 Spacer(Modifier.size(12.dp))
@@ -206,7 +221,7 @@ fun CalculationCard(
                         imeAction = ImeAction.Done
                     ),
                     singleLine = true,
-                    modifier = Modifier.width(150.dp)
+                    modifier = Modifier.weight(1f)
                 )
             }
 

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -71,8 +70,6 @@ fun CreateDishSummaryScreen(
     navController: NavController,
     viewModel: CreateDishV2ViewModel,
 ) {
-    val successfullySavedDishId by viewModel.saveDishSuccess.collectAsState()
-
     CreateDishSummaryContent(
         CreateDishSummaryScreenState(
             dishName = viewModel.dishName.collectAsState().value,
@@ -84,20 +81,20 @@ fun CreateDishSummaryScreen(
             currency = viewModel.currency.collectAsState().value,
             isLoading = viewModel.isLoading.collectAsState().value,
             errorRes = viewModel.errorRes.collectAsState().value,
+            successfullySavedDishId = viewModel.saveDishSuccess.collectAsState().value
         ),
-        successfullySavedDishId = successfullySavedDishId,
         onBackClick = { navController.popBackStack() },
         onSaveDish = { viewModel.onSaveDish() },
         onMarginChange = { viewModel.updateMarginPercentInput(it) },
         onTaxChange = { viewModel.updateTaxPercentInput(it) },
         onErrorDismiss = { viewModel.dismissError() },
         successNavigate = {
-                navController.navigate(FCCScreen.EditDish(it)) {
-                    popUpTo(FCCScreen.Dishes) {
-                        inclusive = false
-                    }
+            navController.navigate(FCCScreen.EditDish(it)) {
+                popUpTo(FCCScreen.Dishes) {
+                    inclusive = false
                 }
-                viewModel.resetSaveDishSuccess()
+            }
+            viewModel.resetSaveDishSuccess()
         }
     )
 }
@@ -106,13 +103,12 @@ fun CreateDishSummaryScreen(
 @Composable
 fun CreateDishSummaryContent(
     state: CreateDishSummaryScreenState,
-    successfullySavedDishId: Long?,
     onBackClick: () -> Unit = {},
     onSaveDish: () -> Unit = {},
     onMarginChange: (String) -> Unit = {},
     onTaxChange: (String) -> Unit = {},
     onErrorDismiss: () -> Unit = {},
-    successNavigate: (Long) -> Unit=  {}
+    successNavigate: (Long) -> Unit = {}
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
@@ -196,9 +192,12 @@ fun CreateDishSummaryContent(
             )
         }
 
-        if (successfullySavedDishId != null) {
-            ConfirmAndNavigate(navigate = { successNavigate(successfullySavedDishId) })
-        }
+        ConfirmAndNavigate(
+            visible = state.successfullySavedDishId != null,
+            navigate = {
+                state.successfullySavedDishId?.let { successNavigate(it) }
+            }
+        )
     }
 }
 
@@ -335,12 +334,12 @@ fun CreateDishSummaryScreenPreview() {
             finalSellingPrice = 3.60,
             currency = Currency.getInstance("GBP"),
             isLoading = false,
-            errorRes = null
+            errorRes = null,
+            successfullySavedDishId = 1L,
         )
 
         CreateDishSummaryContent(
             state = previewState,
-            successfullySavedDishId = 1L,
             onBackClick = {},
             onSaveDish = {},
             onMarginChange = {},

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
@@ -103,6 +103,7 @@ fun CreateDishSummaryScreen(
 @Composable
 fun CreateDishSummaryContent(
     state: CreateDishSummaryScreenState,
+    modifier: Modifier = Modifier,
     onBackClick: () -> Unit = {},
     onSaveDish: () -> Unit = {},
     onMarginChange: (String) -> Unit = {},
@@ -114,6 +115,7 @@ fun CreateDishSummaryContent(
     val focusManager = LocalFocusManager.current
     val interactionSource = remember { MutableInteractionSource() }
     Scaffold(
+        modifier = modifier,
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.dish_cost_and_price, state.dishName)) },
@@ -157,8 +159,8 @@ fun CreateDishSummaryContent(
                     focusManager.clearFocus()
                 },
                 state = state,
-                onMarginChanged = { onMarginChange(it) },
-                onTaxChanged = { onTaxChange(it) }
+                onMarginChange = { onMarginChange(it) },
+                onTaxChange = { onTaxChange(it) }
             )
 
             ButtonRow(
@@ -205,8 +207,8 @@ fun CreateDishSummaryContent(
 fun CalculationCard(
     state: CreateDishSummaryScreenState,
     modifier: Modifier = Modifier,
-    onMarginChanged: (String) -> Unit,
-    onTaxChanged: (String) -> Unit
+    onMarginChange: (String) -> Unit = {},
+    onTaxChange: (String) -> Unit = {}
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -223,7 +225,7 @@ fun CalculationCard(
                 FCCTextField(
                     title = stringResource(R.string.margin),
                     value = state.marginPercent,
-                    onValueChange = onMarginChanged,
+                    onValueChange = onMarginChange,
                     suffix = { Text("%") },
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Decimal,
@@ -238,7 +240,7 @@ fun CalculationCard(
                 FCCTextField(
                     title = stringResource(R.string.tax),
                     value = state.taxPercent,
-                    onValueChange = onTaxChanged,
+                    onValueChange = onTaxChange,
                     suffix = { Text("%") },
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Decimal,
@@ -298,7 +300,7 @@ private fun FoodCost(state: CreateDishSummaryScreenState) {
 @Preview
 @PreviewLightDark
 @Composable
-fun CreateDishSummaryScreenPreview() {
+private fun CreateDishSummaryScreenPreview() {
     FCCTheme {
         val sampleProduct1 = ProductAddedToDish(
             item = ProductDomain(

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
@@ -1,0 +1,309 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishSummary
+
+import android.icu.util.Currency
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.sharp.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.erdees.foodcostcalc.R
+import com.erdees.foodcostcalc.domain.model.product.ProductAddedToDish
+import com.erdees.foodcostcalc.domain.model.product.ProductDomain
+import com.erdees.foodcostcalc.ui.composables.Ingredients
+import com.erdees.foodcostcalc.ui.composables.ScreenLoadingOverlay
+import com.erdees.foodcostcalc.ui.composables.buttons.FCCPrimaryButton
+import com.erdees.foodcostcalc.ui.composables.buttons.FCCTextButton
+import com.erdees.foodcostcalc.ui.composables.dialogs.ErrorDialog
+import com.erdees.foodcostcalc.ui.composables.fields.FCCTextField
+import com.erdees.foodcostcalc.ui.composables.rows.ButtonRow
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.CreateDishV2ViewModel
+import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.SingleServing
+import com.erdees.foodcostcalc.ui.theme.FCCTheme
+import com.erdees.foodcostcalc.utils.Utils
+
+@Composable
+fun CreateDishSummaryScreen(
+    navController: NavController,
+    viewModel: CreateDishV2ViewModel,
+) {
+    CreateDishSummaryContent(
+        CreateDishSummaryScreenState(
+            dishName = viewModel.dishName.collectAsState().value,
+            addedProducts = viewModel.addedProducts.collectAsState().value,
+            foodCost = viewModel.foodCost.collectAsState().value,
+            marginPercent = viewModel.marginPercentInput.collectAsState().value,
+            taxPercent = viewModel.taxPercentInput.collectAsState().value,
+            finalSellingPrice = viewModel.finalSellingPrice.collectAsState().value,
+            currency = viewModel.currency.collectAsState().value,
+            isLoading = viewModel.isLoading.collectAsState().value,
+            errorRes = viewModel.errorRes.collectAsState().value,
+        ),
+        onBackClick = { navController.popBackStack() },
+        onSaveDish = { viewModel.onSaveDish() },
+        onMarginChange = { viewModel.updateMarginPercentInput(it) },
+        onTaxChange = { viewModel.updateTaxPercentInput(it) },
+        onErrorDismiss = { viewModel.dismissError() }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateDishSummaryContent(
+    state: CreateDishSummaryScreenState,
+    onBackClick: () -> Unit = {},
+    onSaveDish: () -> Unit = {},
+    onMarginChange: (String) -> Unit = {},
+    onTaxChange: (String) -> Unit = {},
+    onErrorDismiss: () -> Unit = {}
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.dish_cost_and_price, state.dishName)) },
+                navigationIcon = {
+                    IconButton(onClick = { onBackClick() }) {
+                        Icon(
+                            Icons.AutoMirrored.Sharp.ArrowBack,
+                            contentDescription = stringResource(
+                                id = R.string.back
+                            )
+                        )
+                    }
+                })
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(16.dp)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Ingredients(
+                state.addedProducts,
+                emptyList(),
+                servings = SingleServing,
+                currency = state.currency,
+                showPrices = false,
+                spacious = true
+            )
+
+            CalculationCard(
+                state = state,
+                onMarginChanged = { onMarginChange(it) },
+                onTaxChanged = { onTaxChange(it) }
+            )
+
+            ButtonRow(
+                modifier = Modifier.fillMaxWidth(),
+                primaryButton = {
+                    FCCPrimaryButton(
+                        stringResource(R.string.save_dish),
+                        enabled = !state.isLoading
+                    ) {
+                        onSaveDish()
+                    }
+                },
+                secondaryButton = {
+                    FCCTextButton(
+                        stringResource(R.string.add_more_ingredients),
+                        enabled = !state.isLoading
+                    ) {
+                        onBackClick()
+                    }
+                },
+            )
+        }
+        if (state.isLoading) {
+            ScreenLoadingOverlay(Modifier.fillMaxSize())
+        }
+
+        if (state.errorRes != null) {
+            ErrorDialog(
+                content = stringResource(state.errorRes),
+                onDismiss = { onErrorDismiss() },
+            )
+        }
+    }
+}
+
+@Composable
+fun CalculationCard(
+    state: CreateDishSummaryScreenState,
+    onMarginChanged: (String) -> Unit,
+    onTaxChanged: (String) -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(vertical = 24.dp, horizontal = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            FoodCost(state)
+
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+                FCCTextField(
+                    title = stringResource(R.string.margin),
+                    value = state.marginPercent,
+                    onValueChange = onMarginChanged,
+                    suffix = { Text("%") },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Decimal,
+                        imeAction = ImeAction.Next
+                    ),
+                    singleLine = true,
+                    modifier = Modifier.width(150.dp)
+                )
+
+                Spacer(Modifier.size(12.dp))
+
+                FCCTextField(
+                    title = stringResource(R.string.tax),
+                    value = state.taxPercent,
+                    onValueChange = onTaxChanged,
+                    suffix = { Text("%") },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Decimal,
+                        imeAction = ImeAction.Done
+                    ),
+                    singleLine = true,
+                    modifier = Modifier.width(150.dp)
+                )
+            }
+
+            FinalPrice(state)
+        }
+    }
+}
+
+@Composable
+private fun FinalPrice(state: CreateDishSummaryScreenState) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            stringResource(R.string.final_sell_price),
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+        Text(
+            text = Utils.formatPrice(state.finalSellingPrice, state.currency),
+            style = MaterialTheme.typography.displayMedium,
+            fontWeight = FontWeight.ExtraBold,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun FoodCost(state: CreateDishSummaryScreenState) {
+    Text(
+        text = buildAnnotatedString {
+            append(stringResource(R.string.create_dish_food_cost))
+            append(" ")
+            withStyle(
+                style = SpanStyle(
+                    fontWeight = FontWeight.Black,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                append(Utils.formatPrice(state.foodCost, state.currency))
+            }
+        },
+        style = MaterialTheme.typography.headlineSmall
+    )
+}
+
+@Preview
+@PreviewLightDark
+@Composable
+fun CreateDishSummaryScreenPreview() {
+    FCCTheme {
+        val sampleProduct1 = ProductAddedToDish(
+            item = ProductDomain(
+                id = 0L,
+                name = "Lemon",
+                pricePerUnit = 0.30,
+                unit = "per kilogram",
+                waste = 35.0,
+                tax = 0.0
+            ),
+            quantity = 50.0,
+            quantityUnit = ("gram")
+        )
+        val sampleProduct2 = ProductAddedToDish(
+            item = ProductDomain(
+                id = 2L,
+                name = "Sugar",
+                pricePerUnit = 0.15,
+                unit = "per kilogram",
+                waste = 0.0,
+                tax = 0.0
+            ),
+            quantity = 30.0,
+            quantityUnit = ("gram")
+        )
+
+        val previewState = CreateDishSummaryScreenState(
+            dishName = "Lemonade",
+            addedProducts = listOf(sampleProduct1, sampleProduct2),
+            foodCost = 0.75,
+            marginPercent = "300",
+            taxPercent = "20",
+            finalSellingPrice = 3.60,
+            currency = Currency.getInstance("GBP"),
+            isLoading = false,
+            errorRes = null
+        )
+
+        CreateDishSummaryContent(
+            state = previewState,
+            onBackClick = {},
+            onSaveDish = {},
+            onMarginChange = {},
+            onTaxChange = {}
+        )
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreenState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreenState.kt
@@ -13,5 +13,6 @@ data class CreateDishSummaryScreenState(
     val finalSellingPrice: Double = 0.0,
     val currency: Currency?,
     val isLoading : Boolean,
-    @StringRes val errorRes: Int?
+    @StringRes val errorRes: Int?,
+    val successfullySavedDishId: Long?
 )

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreenState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreenState.kt
@@ -1,0 +1,17 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.createDishSummary
+
+import android.icu.util.Currency
+import androidx.annotation.StringRes
+import com.erdees.foodcostcalc.domain.model.product.ProductAddedToDish
+
+data class CreateDishSummaryScreenState(
+    val dishName: String = "",
+    val addedProducts: List<ProductAddedToDish> = emptyList(),
+    val foodCost: Double = 0.0,
+    val marginPercent: String,
+    val taxPercent: String,
+    val finalSellingPrice: Double = 0.0,
+    val currency: Currency?,
+    val isLoading : Boolean,
+    @StringRes val errorRes: Int?
+)

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/products/createProduct/CreateProductScreenViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/products/createProduct/CreateProductScreenViewModel.kt
@@ -47,21 +47,21 @@ class CreateProductScreenViewModel : ViewModel(), KoinComponent {
     }
 
     private val _productName = MutableStateFlow("")
-    val productName: StateFlow<String> get() = _productName
+    val productName: StateFlow<String> = _productName
 
     fun updateProductName(name: String) {
         _productName.value = name
     }
 
     private val _productPrice = MutableStateFlow("")
-    val productPrice: StateFlow<String> get() = _productPrice
+    val productPrice: StateFlow<String> = _productPrice
 
     fun updateProductPrice(price: String) {
         onNumericValueChange(price, _productPrice)
     }
 
     private val _productTax = MutableStateFlow("")
-    val productTax: StateFlow<String> get() = _productTax
+    val productTax: StateFlow<String> = _productTax
 
     fun updateProductTax(tax: String) {
         if (showTaxPercent.value) {
@@ -70,7 +70,7 @@ class CreateProductScreenViewModel : ViewModel(), KoinComponent {
     }
 
     private val _productWaste = MutableStateFlow("")
-    val productWaste: StateFlow<String> get() = _productWaste
+    val productWaste: StateFlow<String> = _productWaste
 
     fun updateProductWaste(waste: String) {
         onNumericValueChange(waste, _productWaste)

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/products/createProduct/CreateProductScreenViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/products/createProduct/CreateProductScreenViewModel.kt
@@ -11,10 +11,10 @@ import com.erdees.foodcostcalc.data.repository.ProductRepository
 import com.erdees.foodcostcalc.domain.model.InteractionType
 import com.erdees.foodcostcalc.domain.model.ScreenState
 import com.erdees.foodcostcalc.utils.Constants
+import com.erdees.foodcostcalc.utils.MyDispatchers
 import com.erdees.foodcostcalc.utils.Utils
 import com.erdees.foodcostcalc.utils.Utils.formatResultAndCheckCommas
 import com.erdees.foodcostcalc.utils.onNumericValueChange
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -32,10 +32,11 @@ class CreateProductScreenViewModel : ViewModel(), KoinComponent {
     private val productRepository: ProductRepository by inject()
     private val preferences: Preferences by inject()
     private val analyticsRepository: AnalyticsRepository by inject()
+    private val myDispatchers: MyDispatchers by inject()
 
     val showTaxPercent: StateFlow<Boolean> = preferences.showProductTax.stateIn(
         viewModelScope,
-        SharingStarted.WhileSubscribed(5000),
+        SharingStarted.Eagerly,
         true
     )
 
@@ -157,7 +158,7 @@ class CreateProductScreenViewModel : ViewModel(), KoinComponent {
 
     private fun addProduct(product: ProductBase) {
         _screenState.value = ScreenState.Loading<Nothing>()
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(myDispatchers.ioDispatcher) {
             try {
                 productRepository.addProduct(product)
                 _screenState.value = ScreenState.Success(product.name)

--- a/app/src/main/java/com/erdees/foodcostcalc/utils/Constants.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/utils/Constants.kt
@@ -82,6 +82,9 @@ object Constants {
             const val NUMBER_OF_INGREDIENTS = "number_of_ingredients"
             const val DISH_MARGIN = "dish_margin"
             const val DISH_TAX = "dish_tax"
+
+            const val ADD_INGREDIENT_CLICKED = "add_ingredient_clicked"
+            const val ADD_INGREDIENT_TYPE_INTENT = "add_ingredient_type_intent"
         }
     }
 

--- a/app/src/main/java/com/erdees/foodcostcalc/utils/Constants.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/utils/Constants.kt
@@ -30,7 +30,7 @@ object Constants {
         const val DISH_SHARE = "dish_share_click"
         const val DISH_NAME = "dish_name"
 
-        const val AD_FAILED_TO_LOAD =  "ad_failed_to_load"
+        const val AD_FAILED_TO_LOAD = "ad_failed_to_load"
 
         const val LOAD_DATABASE = "load_database"
         const val SAVE_DATABASE = "save_database"
@@ -51,6 +51,38 @@ object Constants {
             const val EVENT = "caught_logged_exception"
             const val MESSAGE = "exception_message"
         }
+
+        object DishV2 {
+            const val PRODUCT_CREATED = "product_created_dishv2"
+            const val DISH_CREATION_STARTED =
+                "dish_creation_started" // When the screen is first entered
+            const val DISH_SAVE_ATTEMPT = "dish_save_attempt"
+            const val DISH_SAVE_SUCCESS =
+                "dish_save_success"       // Already have DISH_CREATED, this is more specific to save action
+            const val DISH_SAVE_FAILURE = "dish_save_failure"
+            const val DISH_INGREDIENT_ADDED = "dish_ingredient_added"
+            const val DISH_INGREDIENT_TYPE = "dish_ingredient_type" // "new" or "existing"
+            const val DISH_INGREDIENT_NAME = "dish_ingredient_name"
+            const val DISH_INGREDIENT_QUANTITY = "dish_ingredient_quantity"
+            const val DISH_INGREDIENT_UNIT = "dish_ingredient_unit"
+            const val NEW_PRODUCT_SAVE_ATTEMPT_FROM_DISH =
+                "new_product_save_attempt_from_dish" // When trying to save a new product *during* dish creation
+            const val NEW_PRODUCT_SAVE_SUCCESS_FROM_DISH = "new_product_save_success_from_dish"
+            const val NEW_PRODUCT_SAVE_FAILURE_FROM_DISH = "new_product_save_failure_from_dish"
+            const val ERROR_DISPLAYED_USER =
+                "error_displayed_user" // When an error is shown to the user
+            const val ERROR_TYPE =
+                "error_type"                     // e.g., "InvalidMargin", "Unexpected"
+            const val ERROR_MESSAGE_RES_ID =
+                "error_message_res_id"       // Resource ID of the error string
+            const val SUGGESTION_SELECTED = "suggestion_selected"
+            const val SUGGESTIONS_MANUALLY_DISMISSED = "suggestions_manually_dismissed"
+
+            // Parameter names (some might overlap with existing ones, which is fine)
+            const val NUMBER_OF_INGREDIENTS = "number_of_ingredients"
+            const val DISH_MARGIN = "dish_margin"
+            const val DISH_TAX = "dish_tax"
+        }
     }
 
     object UI {
@@ -68,7 +100,6 @@ object Constants {
         const val SHOW_HALF_PRODUCTS = "show_half_products"
         const val SHOW_PRODUCT_TAX_PERCENT = "show_product_tax_percent"
     }
-
 
 
     const val BASIC_MARGIN = 100

--- a/app/src/main/java/com/erdees/foodcostcalc/utils/Utils.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/utils/Utils.kt
@@ -150,4 +150,10 @@ object Utils {
     fun formatDouble(decimals: Int, value: Double): Double {
         return BigDecimal(value).setScale(decimals, RoundingMode.HALF_UP).toDouble()
     }
+
+    fun getDishFinalPrice(foodCost: Double, marginPercent: Double, taxPercent: Double) : Double{
+        val priceWithMargin = foodCost * marginPercent / 100
+        val amountOfTax = priceWithMargin * taxPercent / 100
+        return priceWithMargin + amountOfTax
+    }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/utils/Utils.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/utils/Utils.kt
@@ -151,6 +151,7 @@ object Utils {
         return BigDecimal(value).setScale(decimals, RoundingMode.HALF_UP).toDouble()
     }
 
+    @Suppress("MagicNumber")
     fun getDishFinalPrice(foodCost: Double, marginPercent: Double, taxPercent: Double) : Double{
         val priceWithMargin = foodCost * marginPercent / 100
         val amountOfTax = priceWithMargin * taxPercent / 100

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,16 +176,17 @@
 
     <!-- DISHES V2 REVAMP   -->
     <string name="price_your_first_dish">Price your first dish</string>
+    <string name="create_new_dish">Create New Dish</string>
     <string name="dish_name">Dish name</string>
     <string name="final_sell_price">Final Selling Price</string>
     <string name="create_dish_food_cost">Food Cost</string>
     <string name="save_dish">Save Dish</string>
-    <string name="add_more_ingredients">Add More Ingredients Dish</string>
+    <string name="add_more_ingredients">Add More Ingredients</string>
     <string name="dish_cost_and_price">%1$s - Cost &amp; Price</string>
     <string name="add_first_ingredient">Add First Ingredient</string>
     <string name="add_next_ingredient">Add Next Ingredient</string>
     <string name="added_ingredients">Added Ingredients</string>
-    <string name="continue_dish_creation">Continue Dish Creation</string>
+    <string name="continue_dish_creation">Next: Pricing</string>
 
     <string name="invalid_margin_format_error">Invalid margin format. Please enter a valid number.</string>
     <string name="invalid_tax_format_error">Invalid tax format. Please enter a valid number.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,6 +174,24 @@
     <string name="share">Share</string>
     <string name="edit_total_price">Edit Final Price</string>
 
+    <!-- DISHES V2 REVAMP   -->
+    <string name="price_your_first_dish">Price your first dish</string>
+    <string name="dish_name">Dish name</string>
+    <string name="final_sell_price">Final Selling Price</string>
+    <string name="create_dish_food_cost">Food Cost</string>
+    <string name="save_dish">Save Dish</string>
+    <string name="add_more_ingredients">Add More Ingredients Dish</string>
+    <string name="dish_cost_and_price">%1$s - Cost &amp; Price</string>
+    <string name="add_first_ingredient">Add First Ingredient</string>
+    <string name="add_next_ingredient">Add Next Ingredient</string>
+    <string name="added_ingredients">Added Ingredients</string>
+    <string name="continue_dish_creation">Continue Dish Creation</string>
+
+    <string name="invalid_margin_format_error">Invalid margin format. Please enter a valid number.</string>
+    <string name="invalid_tax_format_error">Invalid tax format. Please enter a valid number.</string>
+    <string name="invalid_product_price_error">Invalid product price. Please enter a valid number.</string>
+    <string name="unexpected_error_occurred">An unexpected error occurred.</string>
+
     <!-- Recipe Sharing -->
     <string name="recipe_sharing_prep_time">Preparation time: %1$s minutes.</string>
     <string name="recipe_sharing_cook_time">Cooking Time: %1$s minutes.</string>

--- a/app/src/test/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsViewModelTest.kt
+++ b/app/src/test/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsViewModelTest.kt
@@ -105,7 +105,7 @@ class DishDetailsViewModelTest {
         coEvery { mockDishRepository.getDish(any()) }.returns(flowOf(testDish))
         viewModel = DishDetailsViewModel(savedStateHandle)
         println(testDish.toDishDomain().foodCost)
-        println(testDish.toDishDomain().products.map { it.totalPrice })
+        println(testDish.toDishDomain().products.map { it.foodCost })
         viewModel.updateTotalPrice("123.45")
         viewModel.editableTotalPrice.first() shouldBe "123.45"
     }

--- a/app/src/test/java/com/erdees/foodcostcalc/ui/screens/products/createProduct/CreateProductScreenViewModelTest.kt
+++ b/app/src/test/java/com/erdees/foodcostcalc/ui/screens/products/createProduct/CreateProductScreenViewModelTest.kt
@@ -4,6 +4,7 @@ import com.erdees.foodcostcalc.data.Preferences
 import com.erdees.foodcostcalc.data.model.local.ProductBase
 import com.erdees.foodcostcalc.data.repository.AnalyticsRepository
 import com.erdees.foodcostcalc.data.repository.ProductRepository
+import com.erdees.foodcostcalc.utils.MyDispatchers
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -36,7 +37,7 @@ class CreateProductScreenViewModelTestJUnitStyleWithMockK {
     private lateinit var productRepository: ProductRepository
     private lateinit var preferences: Preferences
     private lateinit var analyticsRepository: AnalyticsRepository
-
+    private lateinit var dispatchers: MyDispatchers
     private lateinit var viewModel: CreateProductScreenViewModel
 
     @Before
@@ -45,6 +46,7 @@ class CreateProductScreenViewModelTestJUnitStyleWithMockK {
 
         productRepository = mockk(relaxed = true)
         preferences = mockk()
+        dispatchers = mockk()
         analyticsRepository = mockk(relaxed = true)
 
         every { preferences.metricUsed } returns flowOf(true)
@@ -53,12 +55,14 @@ class CreateProductScreenViewModelTestJUnitStyleWithMockK {
         every { preferences.defaultMargin } returns flowOf("10")
         every { preferences.defaultTax } returns flowOf("10")
         every { preferences.defaultCurrencyCode } returns flowOf("USD")
+        every { dispatchers.ioDispatcher } returns testDispatcher
 
         startKoin {
             modules(module {
                 single { productRepository }
                 single { preferences }
                 single { analyticsRepository }
+                single { dispatchers }
             })
         }
     }

--- a/app/src/test/java/com/erdees/foodcostcalc/ui/screens/products/createProduct/CreateProductScreenViewModelTest.kt
+++ b/app/src/test/java/com/erdees/foodcostcalc/ui/screens/products/createProduct/CreateProductScreenViewModelTest.kt
@@ -175,7 +175,7 @@ class CreateProductScreenViewModelTestJUnitStyleWithMockK {
     fun `addProduct when showTaxPercent is true uses entered tax value`() =
         runTest(testDispatcher) {
             every { preferences.showProductTax } returns MutableStateFlow(true)
-            coEvery { productRepository.addProduct(any()) } returns Unit
+            coEvery { productRepository.addProduct(any()) } returns 1L
 
             initializeViewModel()
             advanceUntilIdle()
@@ -209,7 +209,7 @@ class CreateProductScreenViewModelTestJUnitStyleWithMockK {
     @Test
     fun `addProduct when showTaxPercent is false uses 0 as tax`() = runTest(testDispatcher) {
             every { preferences.showProductTax } returns MutableStateFlow(false)
-            coEvery { productRepository.addProduct(capture(productBaseSlot)) } returns Unit
+            coEvery { productRepository.addProduct(capture(productBaseSlot)) } returns 1L
 
             initializeViewModel()
             advanceUntilIdle()

--- a/app/src/test/java/com/erdees/foodcostcalc/ui/screens/products/createProduct/CreateProductScreenViewModelTest.kt
+++ b/app/src/test/java/com/erdees/foodcostcalc/ui/screens/products/createProduct/CreateProductScreenViewModelTest.kt
@@ -39,8 +39,6 @@ class CreateProductScreenViewModelTestJUnitStyleWithMockK {
 
     private lateinit var viewModel: CreateProductScreenViewModel
 
-    private val productBaseSlot = slot<ProductBase>()
-
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
@@ -129,19 +127,20 @@ class CreateProductScreenViewModelTestJUnitStyleWithMockK {
         }
 
     @Test
-    fun `addButtonEnabled when showTaxPercent is true and all fields valid`() = runTest(testDispatcher) {
-        every { preferences.showProductTax } returns MutableStateFlow(true)
-        initializeViewModel()
-        advanceUntilIdle()
-        viewModel.updateProductName("Test Product")
-        viewModel.updateProductPrice("10.0")
-        viewModel.updateProductTax("20.0")
-        viewModel.updateProductWaste("5.0")
-        viewModel.selectUnit("kg")
-        advanceUntilIdle()
+    fun `addButtonEnabled when showTaxPercent is true and all fields valid`() =
+        runTest(testDispatcher) {
+            every { preferences.showProductTax } returns MutableStateFlow(true)
+            initializeViewModel()
+            advanceUntilIdle()
+            viewModel.updateProductName("Test Product")
+            viewModel.updateProductPrice("10.0")
+            viewModel.updateProductTax("20.0")
+            viewModel.updateProductWaste("5.0")
+            viewModel.selectUnit("kg")
+            advanceUntilIdle()
 
-        viewModel.addButtonEnabled.value shouldBe true
-    }
+            viewModel.addButtonEnabled.value shouldBe true
+        }
 
     @Test
     fun `addButtonEnabled when showTaxPercent is true and tax is missing`() =
@@ -174,6 +173,7 @@ class CreateProductScreenViewModelTestJUnitStyleWithMockK {
     @Test
     fun `addProduct when showTaxPercent is true uses entered tax value`() =
         runTest(testDispatcher) {
+            val productBaseSlot = slot<ProductBase>()
             every { preferences.showProductTax } returns MutableStateFlow(true)
             coEvery { productRepository.addProduct(any()) } returns 1L
 
@@ -208,33 +208,34 @@ class CreateProductScreenViewModelTestJUnitStyleWithMockK {
 
     @Test
     fun `addProduct when showTaxPercent is false uses 0 as tax`() = runTest(testDispatcher) {
-            every { preferences.showProductTax } returns MutableStateFlow(false)
-            coEvery { productRepository.addProduct(capture(productBaseSlot)) } returns 1L
+        val productBaseSlot = slot<ProductBase>()
+        every { preferences.showProductTax } returns MutableStateFlow(false)
+        coEvery { productRepository.addProduct(capture(productBaseSlot)) } returns 1L
 
-            initializeViewModel()
-            advanceUntilIdle()
+        initializeViewModel()
+        advanceUntilIdle()
 
-            viewModel.updateProductName("Test Product")
-            viewModel.updateProductPrice("10.0")
-            viewModel.updateProductWaste("5.0")
-            viewModel.selectUnit("kg")
-            advanceUntilIdle()
-            viewModel.addProduct()
-            advanceUntilIdle()
+        viewModel.updateProductName("Test Product")
+        viewModel.updateProductPrice("10.0")
+        viewModel.updateProductWaste("5.0")
+        viewModel.selectUnit("kg")
+        advanceUntilIdle()
+        viewModel.addProduct()
+        advanceUntilIdle()
 
-            coVerify { productRepository.addProduct(any()) }
-            val capturedProduct = productBaseSlot.captured
-            capturedProduct.name shouldBe "Test Product"
-            capturedProduct.pricePerUnit shouldBe 10.0
-            capturedProduct.tax shouldBe 0.0
-            capturedProduct.waste shouldBe 5.0
-            capturedProduct.unit shouldBe "kg"
+        coVerify { productRepository.addProduct(any()) }
+        val capturedProduct = productBaseSlot.captured
+        capturedProduct.name shouldBe "Test Product"
+        capturedProduct.pricePerUnit shouldBe 10.0
+        capturedProduct.tax shouldBe 0.0
+        capturedProduct.waste shouldBe 5.0
+        capturedProduct.unit shouldBe "kg"
 
-            coVerify(exactly = 1) {
-                analyticsRepository.logEvent(
-                    any(),
-                    any()
-                )
-            }
+        coVerify(exactly = 1) {
+            analyticsRepository.logEvent(
+                any(),
+                any()
+            )
         }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,3 +105,4 @@ compose-rules-detekt = { group = "io.nlopez.compose.rules", name = "detekt", ver
 androidx-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidx_datastore"}
 canary-leak = { group = "com.squareup.leakcanary", name = "leakcanary-android", version = "2.14" }
 firebase-appcheck = { group = "com.google.firebase", name = "firebase-appcheck-playintegrity" }
+kotlinx-immutable-collections = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version = "0.4.0"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,7 @@ lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-view
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity_ktx" }
 play-review = { group = "com.google.android.play", name = "review", version.ref = "review" }
 play-review-ktx = { group = "com.google.android.play", name = "review-ktx", version.ref = "review" }


### PR DESCRIPTION
Quite a huge feature this multi step Create Dish

- 2 screens for dish creation
- 1 step has 2 small VMs that manage modals and 1 large VM that is shared with 2nd screen
- Got to figure out how to make CreateDishV2ViewModel a bit smaller, perhaps split into smaller chunks, or even use cases could be introduced for the operations as they are quite complex.

- Largely done, although a lot of fine tuning needed to make this ready. Navigation, UI, error handling missing in 1st screen. Pushing this to not lose it in case my laptop explodes.