### PR TITLE
Fix: Disable MagicNumber rule in Detekt

### DIFF
--- a/config/detekt/config.yml
+++ b/config/detekt/config.yml
@@ -607,7 +607,7 @@ style:
     active: true
     maxJumpCount: 1
   MagicNumber:
-    active: true
+    active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/*.kts']
     ignoreNumbers:
       - '-1'


### PR DESCRIPTION
The MagicNumber rule has been disabled in the Detekt configuration as it was proving to be annoying and unnecessary.