### PR TITLE
Fix Subscription Screen

### DIFF
--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/subscriptionScreen/SubscriptionScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/subscriptionScreen/SubscriptionScreen.kt
@@ -22,8 +22,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,9 +37,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -68,20 +64,7 @@ fun SubscriptionScreen(
 ) {
     val context = LocalContext.current
     val activity = context.getActivity()
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val screenState by viewModel.screenState.collectAsState()
-
-    DisposableEffect(Unit) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                    viewModel.updateSubscriptionStatus()
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-        }
-    }
+    val screenState by viewModel.screenState.collectAsStateWithLifecycle()
 
     SubscriptionScreenContent(
         navController = navController,


### PR DESCRIPTION
This commit changes the subscription status update mechanism from manual updates in `onResume` to using `collectAsStateWithLifecycle`. This ensures the UI automatically reflects the latest subscription status.

- Removed manual `updateSubscriptionStatus` and `DisposableEffect` from `SubscriptionScreen.kt`.
- Introduced `collectAsStateWithLifecycle` in `SubscriptionScreen.kt` to observe `screenState`.
- Added `observeSubscriptionChanges` in `SubscriptionViewModel.kt` to collect latest subscription status from preferences and update `screenState`.
- Removed `updateSubscriptionStatus` from `SubscriptionViewModel.kt`.