### PR TITLE
Ensure Spotlight logs completion only after stopping

### DIFF
--- a/app/src/main/java/com/erdees/foodcostcalc/ui/spotlight/Spotlight.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/spotlight/Spotlight.kt
@@ -68,7 +68,6 @@ class Spotlight(private val scope: CoroutineScope) : KoinComponent {
             logStepShown()
             scrollToCurrentTarget()
         } else {
-            logCompleted()
             stop()
         }
     }
@@ -76,6 +75,7 @@ class Spotlight(private val scope: CoroutineScope) : KoinComponent {
     /** Stops the spotlight tour and cleans up the state. */
     private fun stop() {
         Timber.i("Spotlight stopping.")
+        logCompleted()
         currentIndex = -1
         targets = emptyList()
     }


### PR DESCRIPTION
The `logCompleted()` function was being called before the spotlight was fully stopped. This commit moves the `logCompleted()` call to within the `stop()` function to ensure it's logged only after the spotlight tour is properly cleaned up.