### PR TITLE
S.T.A.Y. Copy Dish - Need to Refactor but eager to release

### DIFF
--- a/app/src/main/java/com/erdees/foodcostcalc/domain/mapper/Mapper.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/mapper/Mapper.kt
@@ -211,6 +211,20 @@ object Mapper {
         return this.toRecipeDomain().toEditableRecipe()
     }
 
+    fun RecipeDomain.toRecipe(id: Long? = null): Recipe {
+        return Recipe(
+            recipeId = id ?: 0,
+            cookTimeMinutes = cookTimeMinutes,
+            prepTimeMinutes = prepTimeMinutes,
+            description = description,
+            tips = tips
+        )
+    }
+
+    fun RecipeDomain.toSteps() : List<RecipeStep> {
+        return steps?.map { it.toRecipeStep(recipeId = recipeId ?: 0) } ?: emptyList()
+    }
+
 
     fun EditableRecipe.toRecipe(id: Long?): Recipe {
         return Recipe(

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/mapper/Mapper.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/mapper/Mapper.kt
@@ -99,7 +99,7 @@ object Mapper {
         )
     }
 
-    fun ProductAndProductDish.toUsedProductDomain(): UsedProductDomain {
+    private fun ProductAndProductDish.toUsedProductDomain(): UsedProductDomain {
         return UsedProductDomain(
             id = productDish.productDishId,
             ownerId = productDish.dishId,
@@ -110,7 +110,7 @@ object Mapper {
         )
     }
 
-    fun ProductUsedInHalfProduct.toUsedProductDomain(): UsedProductDomain {
+    private fun ProductUsedInHalfProduct.toUsedProductDomain(): UsedProductDomain {
         return UsedProductDomain(
             id = productHalfProduct.productHalfProductId,
             ownerId = productHalfProduct.halfProductId,

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/ScreenState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/ScreenState.kt
@@ -10,7 +10,7 @@ sealed class InteractionType {
     data class EditQuantity(val itemId: Long) : InteractionType()
     data object ChangeServings : InteractionType()
     data object UnsavedChangesConfirmation : InteractionType()
-    data object CopyDish : InteractionType()
+    data class CopyDish(val prefilledName: String) : InteractionType()
 
     data object CalculateWaste : InteractionType()
     data object CalculatePiecePrice : InteractionType()

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/ScreenState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/ScreenState.kt
@@ -10,6 +10,7 @@ sealed class InteractionType {
     data class EditQuantity(val itemId: Long) : InteractionType()
     data object ChangeServings : InteractionType()
     data object UnsavedChangesConfirmation : InteractionType()
+    data object UnsavedChangesConfirmationBeforeCopy : InteractionType()
     data class CopyDish(val prefilledName: String) : InteractionType()
 
     data object CalculateWaste : InteractionType()

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/ScreenState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/ScreenState.kt
@@ -10,6 +10,7 @@ sealed class InteractionType {
     data class EditQuantity(val itemId: Long) : InteractionType()
     data object ChangeServings : InteractionType()
     data object UnsavedChangesConfirmation : InteractionType()
+    data object CopyDish : InteractionType()
 
     data object CalculateWaste : InteractionType()
     data object CalculatePiecePrice : InteractionType()

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishActionResult.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishActionResult.kt
@@ -1,6 +1,6 @@
 package com.erdees.foodcostcalc.domain.model.dish
 
 data class DishActionResult(
-    val type: DishActionResultType,
+    val type: DishDetailsActionResultType,
     val dishId: Long
 )

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishActionResult.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishActionResult.kt
@@ -1,0 +1,6 @@
+package com.erdees.foodcostcalc.domain.model.dish
+
+data class DishActionResult(
+    val type: DishActionResultType,
+    val dishId: Long
+)

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishActionResultType.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishActionResultType.kt
@@ -1,0 +1,19 @@
+package com.erdees.foodcostcalc.domain.model.dish
+
+/**
+ * Represents the result of an action performed on a dish.
+ * Used with ScreenState.Success to communicate specific outcomes to the UI.
+ */
+enum class DishActionResultType {
+    /** Dish has been created */
+    CREATED,
+
+    /** Dish has been updated */
+    UPDATED,
+
+    /** Dish has been copied */
+    COPIED,
+
+    /** Dish has been deleted */
+    DELETED
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishDetailsActionResultType.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/dish/DishDetailsActionResultType.kt
@@ -4,12 +4,12 @@ package com.erdees.foodcostcalc.domain.model.dish
  * Represents the result of an action performed on a dish.
  * Used with ScreenState.Success to communicate specific outcomes to the UI.
  */
-enum class DishActionResultType {
-    /** Dish has been created */
-    CREATED,
-
+enum class DishDetailsActionResultType {
     /** Dish has been updated */
-    UPDATED,
+    UPDATED_NAVIGATE,
+
+    /** Dish has been updated but we want to stay in the screen*/
+    UPDATED_STAY,
 
     /** Dish has been copied */
     COPIED,

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/usecase/CopyDishUseCase.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/usecase/CopyDishUseCase.kt
@@ -12,7 +12,7 @@ import com.erdees.foodcostcalc.domain.mapper.Mapper.toProductDish
 import com.erdees.foodcostcalc.domain.mapper.Mapper.toRecipe
 import com.erdees.foodcostcalc.domain.mapper.Mapper.toSteps
 import com.erdees.foodcostcalc.domain.model.dish.DishActionResult
-import com.erdees.foodcostcalc.domain.model.dish.DishActionResultType
+import com.erdees.foodcostcalc.domain.model.dish.DishDetailsActionResultType
 import com.erdees.foodcostcalc.domain.model.dish.DishDomain
 import com.erdees.foodcostcalc.utils.Constants
 import com.erdees.foodcostcalc.utils.MyDispatchers
@@ -37,7 +37,7 @@ class CopyDishUseCase(
 
                 Result.success(
                     DishActionResult(
-                        type = DishActionResultType.COPIED,
+                        type = DishDetailsActionResultType.COPIED,
                         dishId = newDishId
                     )
                 )

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/usecase/CopyDishUseCase.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/usecase/CopyDishUseCase.kt
@@ -1,0 +1,96 @@
+package com.erdees.foodcostcalc.domain.usecase
+
+import android.os.Bundle
+import com.erdees.foodcostcalc.data.repository.AnalyticsRepository
+import com.erdees.foodcostcalc.data.repository.DishRepository
+import com.erdees.foodcostcalc.data.repository.HalfProductRepository
+import com.erdees.foodcostcalc.data.repository.ProductRepository
+import com.erdees.foodcostcalc.data.repository.RecipeRepository
+import com.erdees.foodcostcalc.domain.mapper.Mapper.toDishBase
+import com.erdees.foodcostcalc.domain.mapper.Mapper.toHalfProductDish
+import com.erdees.foodcostcalc.domain.mapper.Mapper.toProductDish
+import com.erdees.foodcostcalc.domain.mapper.Mapper.toRecipe
+import com.erdees.foodcostcalc.domain.mapper.Mapper.toSteps
+import com.erdees.foodcostcalc.domain.model.dish.DishActionResult
+import com.erdees.foodcostcalc.domain.model.dish.DishActionResultType
+import com.erdees.foodcostcalc.domain.model.dish.DishDomain
+import com.erdees.foodcostcalc.utils.Constants
+import com.erdees.foodcostcalc.utils.MyDispatchers
+import kotlinx.coroutines.withContext
+
+class CopyDishUseCase(
+    private val dishRepository: DishRepository,
+    private val productRepository: ProductRepository,
+    private val halfProductRepository: HalfProductRepository,
+    private val recipeRepository: RecipeRepository,
+    private val analyticsRepository: AnalyticsRepository,
+    private val myDispatchers: MyDispatchers
+) {
+    suspend operator fun invoke(dish: DishDomain, newName: String): Result<DishActionResult> =
+        withContext(myDispatchers.ioDispatcher) {
+            try {
+                val copiedRecipeId = copyRecipeWithSteps(dish)
+                val newDishId = createDishCopy(dish, newName, copiedRecipeId)
+                copyDishProducts(dish, newDishId)
+                copyDishHalfProducts(dish, newDishId)
+                logDishCopyEvent(newName)
+
+                Result.success(
+                    DishActionResult(
+                        type = DishActionResultType.COPIED,
+                        dishId = newDishId
+                    )
+                )
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    private suspend fun copyRecipeWithSteps(dish: DishDomain): Long? {
+        val recipe = dish.recipe?.toRecipe() ?: return null
+        val recipeId = recipeRepository.upsertRecipe(recipe)
+
+        dish.recipe.toSteps().let { steps ->
+            recipeRepository.upsertRecipeSteps(steps.map { it.copy(recipeId = recipeId) })
+        }
+
+        return recipeId
+    }
+
+    private suspend fun createDishCopy(dish: DishDomain, newName: String, recipeId: Long?): Long {
+        val dishCopy = dish.copy(
+            id = 0L,
+            name = newName,
+        ).toDishBase().copy(
+            recipeId = recipeId
+        )
+
+        return dishRepository.addDish(dishCopy)
+    }
+
+    private suspend fun copyDishProducts(dish: DishDomain, newDishId: Long) {
+        dish.products.forEach { product ->
+            val productCopy = product.copy(
+                id = 0L,
+                ownerId = newDishId
+            )
+            productRepository.addProductDish(productCopy.toProductDish())
+        }
+    }
+
+    private suspend fun copyDishHalfProducts(dish: DishDomain, newDishId: Long) {
+        dish.halfProducts.forEach { halfProduct ->
+            val halfProductCopy = halfProduct.copy(
+                id = 0L,
+                ownerId = newDishId
+            )
+            halfProductRepository.addHalfProductDish(halfProductCopy.toHalfProductDish())
+        }
+    }
+
+    private fun logDishCopyEvent(dishName: String) {
+        analyticsRepository.logEvent(Constants.Analytics.DishV2.COPY, Bundle().apply {
+            putString(Constants.Analytics.DISH_NAME, dishName)
+        })
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/usecase/di/UseCaseModule.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/usecase/di/UseCaseModule.kt
@@ -1,5 +1,6 @@
 package com.erdees.foodcostcalc.domain.usecase.di
 
+import com.erdees.foodcostcalc.domain.usecase.CopyDishUseCase
 import com.erdees.foodcostcalc.domain.usecase.SubmitFeatureRequestUseCase
 import org.koin.dsl.module
 
@@ -10,6 +11,16 @@ val useCaseModule = module {
             featureRequestService = get(),
             featureRequestRepository = get(),
             dispatchers = get()
+        )
+    }
+    factory {
+        CopyDishUseCase(
+            dishRepository = get(),
+            productRepository = get(),
+            halfProductRepository = get(),
+            recipeRepository = get(),
+            analyticsRepository = get(),
+            myDispatchers = get()
         )
     }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/ConfirmPopUp.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/ConfirmPopUp.kt
@@ -45,13 +45,20 @@ import kotlin.math.cos
 import kotlin.math.sin
 
 
-@Suppress("MagicNumber")
+/**
+ * A full-screen confirmation pop-up that shows an animated checkmark and then navigates.
+ *
+ * @param visible Controls the visibility of the pop-up. When set to true, the animation sequence begins.
+ * @param modifier The [Modifier] to be applied to this composable.
+ * @param progress The initial progress of the checkmark animation (from 0.0f to 1.0f).
+ * @param actionAfter An optional lambda that is called after the animation has finished.
+ */
 @Composable
-fun ConfirmAndNavigate(
+fun ConfirmPopUp(
     visible: Boolean,
     modifier: Modifier = Modifier,
     progress: Float = 0f,
-    navigate: () -> Unit = {},
+    actionAfter: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val configuration = LocalWindowInfo.current
@@ -59,7 +66,7 @@ fun ConfirmAndNavigate(
     val screenHeight = configuration.containerSize.height.dp
     val checkmarkProgress = remember { Animatable(progress) }
     val animationDuration = 300
-    val currentNavigate by rememberUpdatedState(newValue = navigate)
+    val currentActionAfter by rememberUpdatedState(newValue = actionAfter)
 
     val cornerRadius by animateIntAsState(
         targetValue = if (visible) 0 else 100,
@@ -87,7 +94,7 @@ fun ConfirmAndNavigate(
                 )
             )
             delay(animationDuration * 2L)
-            currentNavigate()
+            currentActionAfter()
         }
     }
 
@@ -198,7 +205,7 @@ private fun ConfirmAndNavigate_ProgressPreview(
     @PreviewParameter(ProgressPreviewParameterProvider::class) progress: Float
 ) {
     FCCTheme {
-        ConfirmAndNavigate(true, progress = progress, modifier = Modifier.size(200.dp))
+        ConfirmPopUp(true, progress = progress, modifier = Modifier.size(200.dp))
     }
 }
 
@@ -211,6 +218,6 @@ private fun ConfirmAndNavigate_ProgressPreview(
 @Composable
 private fun InteractiveConfirmAndNavigatePreview() {
     FCCTheme {
-        ConfirmAndNavigate(true)
+        ConfirmPopUp(true)
     }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/FCCNavigation.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/FCCNavigation.kt
@@ -86,7 +86,10 @@ fun FCCNavigation(
 
         composable<FCCScreen.DishDetails> { backStackEntry ->
             val route: FCCScreen.DishDetails = backStackEntry.toRoute()
-            DishDetailsScreen(dishId = route.dishId, navController = navController)
+            DishDetailsScreen(
+                dishId = route.dishId,
+                navController = navController
+            )
         }
 
         composable<FCCScreen.Recipe> { backStackEntry ->
@@ -119,7 +122,7 @@ fun FCCNavigation(
 
         composable<FCCScreen.CreateDishSummary>(
             enterTransition = { slideInHorizontally { it } },
-            popExitTransition = { slideOutHorizontally { it }}
+            popExitTransition = { slideOutHorizontally { it } }
         ) { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
                 navController.getBackStackEntry(navController.previousBackStackEntry?.destination?.route.toString())

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/FCCScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/navigation/FCCScreen.kt
@@ -45,7 +45,10 @@ sealed class FCCScreen(
     data class AddItemsToDish(val dishId: Long, val dishName: String) : FCCScreen()
 
     @Serializable
-    data class DishDetails(@SerialName(DISH_ID_KEY) val dishId: Long) : FCCScreen()
+    data class DishDetails(
+        @SerialName(DISH_ID_KEY) val dishId: Long,
+        @SerialName(IS_COPIED) val isCopied: Boolean = false
+    ) : FCCScreen()
 
     @Serializable
     data object CreateDish : FCCScreen()
@@ -57,7 +60,8 @@ sealed class FCCScreen(
     data object CreateDishSummary : FCCScreen()
 
     @Serializable
-    data class EditHalfProduct(@SerialName(HALF_PRODUCT_ID_KEY) val halfProductId: Long) : FCCScreen()
+    data class EditHalfProduct(@SerialName(HALF_PRODUCT_ID_KEY) val halfProductId: Long) :
+        FCCScreen()
 
     @Serializable
     data class EditProduct(@SerialName(PRODUCT_ID_KEY) val productId: Long) : FCCScreen()
@@ -78,6 +82,7 @@ sealed class FCCScreen(
     data object Onboarding : FCCScreen()
 
     companion object {
+        const val IS_COPIED = "isCopied"
         const val DISH_ID_KEY = "dishId"
         const val PRODUCT_ID_KEY = "productId"
         const val HALF_PRODUCT_ID_KEY = "halfProductId"

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/DishesScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/DishesScreen.kt
@@ -150,7 +150,7 @@ fun DishesScreen(
                 )
             },
             onEditClick = { dishId ->
-                navController.navigate(FCCScreen.DishDetails(dishId))
+                navController.navigate(FCCScreen.DishDetails(dishId, false))
             }
         )
     }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/createDishSummary/CreateDishSummaryScreen.kt
@@ -58,7 +58,7 @@ import com.erdees.foodcostcalc.ui.composables.buttons.FCCTextButton
 import com.erdees.foodcostcalc.ui.composables.dialogs.ErrorDialog
 import com.erdees.foodcostcalc.ui.composables.fields.FCCTextField
 import com.erdees.foodcostcalc.ui.composables.rows.ButtonRow
-import com.erdees.foodcostcalc.ui.navigation.ConfirmAndNavigate
+import com.erdees.foodcostcalc.ui.navigation.ConfirmPopUp
 import com.erdees.foodcostcalc.ui.navigation.FCCScreen
 import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.CreateDishV2ViewModel
 import com.erdees.foodcostcalc.ui.screens.dishes.createDishV2.SingleServing
@@ -194,9 +194,9 @@ fun CreateDishSummaryContent(
             )
         }
 
-        ConfirmAndNavigate(
+        ConfirmPopUp(
             visible = state.successfullySavedDishId != null,
-            navigate = {
+            actionAfter = {
                 state.successfullySavedDishId?.let { successNavigate(it) }
             }
         )

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetails.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetails.kt
@@ -1,0 +1,73 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.editDish
+
+import android.icu.util.Currency
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.erdees.foodcostcalc.R
+import com.erdees.foodcostcalc.domain.model.dish.DishDomain
+import com.erdees.foodcostcalc.ui.composables.DetailItem
+import com.erdees.foodcostcalc.utils.Utils
+
+@Composable
+fun DishDetails(
+    dishDomain: DishDomain,
+    currency: Currency?,
+    onTaxClick: () -> Unit,
+    onMarginClick: () -> Unit,
+    onTotalPriceClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        Row {
+            DetailItem(
+                label = stringResource(R.string.margin),
+                value = "${dishDomain.marginPercent}%",
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .weight(1f)
+                    .clickable {
+                        onMarginClick()
+                    })
+            DetailItem(
+                label = stringResource(R.string.tax),
+                value = "${dishDomain.taxPercent}%",
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .weight(1f)
+                    .clickable {
+                        onTaxClick()
+                    })
+        }
+
+        Spacer(modifier = Modifier.size(8.dp))
+
+        Row {
+            DetailItem(
+                label = stringResource(R.string.food_cost),
+                value = Utils.formatPrice(dishDomain.foodCost, currency),
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .weight(1f)
+            )
+            DetailItem(
+                label = stringResource(R.string.final_price),
+                value = Utils.formatPrice(dishDomain.totalPrice, currency),
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .weight(1f)
+                    .clickable(enabled = dishDomain.foodCost != 0.0) {
+                        onTotalPriceClick()
+                    },
+                bolder = true
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
@@ -275,125 +275,153 @@ private fun EditDishScreenContent(
                     }
                 }
 
-                when (screenState) {
-                    is ScreenState.Loading<*> -> ScreenLoadingOverlay()
-                    is ScreenState.Success<*> -> {} // NOTHING
-
-                    is ScreenState.Error -> {
-                        ErrorDialog {
-                            callbacks.resetScreenState()
-                        }
-                    }
-
-                    is ScreenState.Interaction -> {
-                        when (screenState.interaction) {
-                            InteractionType.EditTax -> {
-                                ValueEditDialog(
-                                    title = stringResource(R.string.edit_tax),
-                                    value = editableTax,
-                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                    updateValue = { callbacks.updateTax(it) },
-                                    onSave = { callbacks.saveTax() },
-                                    onDismiss = { callbacks.resetScreenState() })
-                            }
-
-                            InteractionType.EditMargin -> {
-                                ValueEditDialog(
-                                    title = stringResource(R.string.edit_margin),
-                                    value = editableMargin,
-                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                    updateValue = { callbacks.updateMargin(it) },
-                                    onSave = { callbacks.saveMargin() },
-                                    onDismiss = { callbacks.resetScreenState() })
-                            }
-
-                            InteractionType.EditTotalPrice -> {
-                                ValueEditDialog(
-                                    title = stringResource(R.string.edit_total_price),
-                                    value = editableTotalPrice,
-                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                    updateValue = { callbacks.updateTotalPrice(it) },
-                                    onSave = { callbacks.saveTotalPrice() },
-                                    onDismiss = { callbacks.resetScreenState() })
-                            }
-
-                            InteractionType.EditName -> {
-                                ValueEditDialog(
-                                    title = stringResource(R.string.edit_name),
-                                    value = editableName,
-                                    updateValue = { callbacks.updateName(it) },
-                                    onSave = { callbacks.saveName() },
-                                    onDismiss = { callbacks.resetScreenState() },
-                                    keyboardOptions = KeyboardOptions(
-                                        keyboardType = KeyboardType.Text,
-                                        capitalization = KeyboardCapitalization.Words
-                                    )
-                                )
-                            }
-
-                            is InteractionType.CopyDish -> {
-                                ValueEditDialog(
-                                    title = stringResource(R.string.copy_dish),
-                                    value = editableCopiedDishName,
-                                    updateValue = { callbacks.updateCopiedDishName(it) },
-                                    onSave = { callbacks.copyDish() },
-                                    onDismiss = { callbacks.resetScreenState() },
-                                    keyboardOptions = KeyboardOptions(
-                                        keyboardType = KeyboardType.Text,
-                                        capitalization = KeyboardCapitalization.Words
-                                    )
-                                )
-                            }
-
-                            is InteractionType.EditItem -> {
-                                ValueEditDialog(
-                                    title = stringResource(R.string.edit_quantity),
-                                    value = editableQuantity,
-                                    keyboardOptions = KeyboardOptions(
-                                        keyboardType = KeyboardType.Number,
-                                        capitalization = KeyboardCapitalization.Words
-                                    ),
-                                    updateValue = { callbacks.updateQuantity(it) },
-                                    onSave = { callbacks.saveQuantity() },
-                                    onDismiss = { callbacks.resetScreenState() })
-                            }
-
-                            is InteractionType.DeleteConfirmation -> {
-                                val deleteConfirmation = screenState.interaction
-                                FCCDeleteConfirmationDialog(
-                                    itemName = deleteConfirmation.itemName,
-                                    onDismiss = { callbacks.resetScreenState() },
-                                    onConfirmDelete = {
-                                        callbacks.onDeleteConfirmed(deleteConfirmation.itemId)
-                                    })
-                            }
-
-                            InteractionType.UnsavedChangesConfirmation -> {
-                                FCCUnsavedChangesDialog(
-                                    onDismiss = { callbacks.resetScreenState() },
-                                    onDiscard = { callbacks.discardAndNavigate { navController.popBackStack() } },
-                                    onSave = { callbacks.saveAndNavigate() })
-                            }
-
-                            is InteractionType.UnsavedChangesConfirmationBeforeCopy -> {
-                                FCCUnsavedChangesDialog(
-                                    onDismiss = callbacks.resetScreenState,
-                                    onDiscard = callbacks.discardChangesAndProceed,
-                                    onSave = callbacks.saveChangesAndProceed
-                                )
-                            }
-
-                            else -> {}
-                        }
-                    }
-
-                    is ScreenState.Idle -> {}
-                }
+                ScreenStateHandler(state, callbacks, navController)
 
                 ConfirmPopUp(visible = showCopyConfirmation) {
                     callbacks.hideCopyConfirmation()
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun ScreenStateHandler(
+    state: EditDishScreenState,
+    callbacks: EditDishScreenCallbacks,
+    navController: NavController,
+) {
+    with(state) {
+        when (screenState) {
+            is ScreenState.Loading<*> -> ScreenLoadingOverlay()
+            is ScreenState.Success<*> -> {} // NOTHING
+
+            is ScreenState.Error -> {
+                ErrorDialog {
+                    callbacks.resetScreenState()
+                }
+            }
+
+            is ScreenState.Interaction -> {
+                InteractionHandler(
+                    interaction = screenState.interaction,
+                    state = state,
+                    callbacks = callbacks,
+                    navController = navController
+                )
+            }
+
+            is ScreenState.Idle -> {}
+        }
+    }
+}
+
+@Composable
+private fun InteractionHandler(
+    interaction: InteractionType,
+    state: EditDishScreenState,
+    callbacks: EditDishScreenCallbacks,
+    navController: NavController
+) {
+    with(state) {
+        when (interaction) {
+            InteractionType.EditTax -> {
+                ValueEditDialog(
+                    title = stringResource(R.string.edit_tax),
+                    value = editableTax,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    updateValue = { callbacks.updateTax(it) },
+                    onSave = { callbacks.saveTax() },
+                    onDismiss = { callbacks.resetScreenState() })
+            }
+
+            InteractionType.EditMargin -> {
+                ValueEditDialog(
+                    title = stringResource(R.string.edit_margin),
+                    value = editableMargin,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    updateValue = { callbacks.updateMargin(it) },
+                    onSave = { callbacks.saveMargin() },
+                    onDismiss = { callbacks.resetScreenState() })
+            }
+
+            InteractionType.EditTotalPrice -> {
+                ValueEditDialog(
+                    title = stringResource(R.string.edit_total_price),
+                    value = editableTotalPrice,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    updateValue = { callbacks.updateTotalPrice(it) },
+                    onSave = { callbacks.saveTotalPrice() },
+                    onDismiss = { callbacks.resetScreenState() })
+            }
+
+            InteractionType.EditName -> {
+                ValueEditDialog(
+                    title = stringResource(R.string.edit_name),
+                    value = editableName,
+                    updateValue = { callbacks.updateName(it) },
+                    onSave = { callbacks.saveName() },
+                    onDismiss = { callbacks.resetScreenState() },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Text,
+                        capitalization = KeyboardCapitalization.Words
+                    )
+                )
+            }
+
+            is InteractionType.CopyDish -> {
+                ValueEditDialog(
+                    title = stringResource(R.string.copy_dish),
+                    value = editableCopiedDishName,
+                    updateValue = { callbacks.updateCopiedDishName(it) },
+                    onSave = { callbacks.copyDish() },
+                    onDismiss = { callbacks.resetScreenState() },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Text,
+                        capitalization = KeyboardCapitalization.Words
+                    )
+                )
+            }
+
+            is InteractionType.EditItem -> {
+                ValueEditDialog(
+                    title = stringResource(R.string.edit_quantity),
+                    value = editableQuantity,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        capitalization = KeyboardCapitalization.Words
+                    ),
+                    updateValue = { callbacks.updateQuantity(it) },
+                    onSave = { callbacks.saveQuantity() },
+                    onDismiss = { callbacks.resetScreenState() })
+            }
+
+            is InteractionType.DeleteConfirmation -> {
+                val deleteConfirmation = interaction
+                FCCDeleteConfirmationDialog(
+                    itemName = deleteConfirmation.itemName,
+                    onDismiss = { callbacks.resetScreenState() },
+                    onConfirmDelete = {
+                        callbacks.onDeleteConfirmed(deleteConfirmation.itemId)
+                    })
+            }
+
+            InteractionType.UnsavedChangesConfirmation -> {
+                FCCUnsavedChangesDialog(
+                    onDismiss = { callbacks.resetScreenState() },
+                    onDiscard = { callbacks.discardAndNavigate { navController.popBackStack() } },
+                    onSave = { callbacks.saveAndNavigate() })
+            }
+
+            is InteractionType.UnsavedChangesConfirmationBeforeCopy -> {
+                FCCUnsavedChangesDialog(
+                    onDismiss = callbacks.resetScreenState,
+                    onDiscard = callbacks.discardChangesAndProceed,
+                    onSave = callbacks.saveChangesAndProceed
+                )
+            }
+
+            else -> {}
         }
     }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
@@ -3,8 +3,6 @@ package com.erdees.foodcostcalc.ui.screens.dishes.editDish
 import android.content.Context
 import android.icu.util.Currency
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -182,7 +180,6 @@ fun DishDetailsScreen(
             onDeleteConfirmed = viewModel::confirmDelete,
             copyDish = viewModel::copyDish,
             updateCopiedDishName = viewModel::updateCopiedDishName,
-            onDeleteConfirmed = viewModel::confirmDelete,
             discardChanges = viewModel::discardChanges,
             saveAndNavigate = viewModel::saveAndNavigate
         )
@@ -508,5 +505,5 @@ private fun EditDishScreenContentPreview(
 }
 
 private fun createEmptyEditDishScreenCallbacks() = EditDishScreenCallbacks(
-    {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+    {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
 )

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
@@ -192,6 +192,7 @@ private fun EditDishScreenContent(
     callbacks: EditDishScreenCallbacks,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
     with(state) {
         Scaffold(
             modifier = modifier,
@@ -200,7 +201,9 @@ private fun EditDishScreenContent(
                     dishName = modifiedDishDomain?.name ?: dishId.toString(),
                     onNameClick = { callbacks.setInteraction(InteractionType.EditName) },
                     onDeleteClick = { callbacks.onDeleteDishClick() },
-                    onCopyClick = { callbacks.setInteraction(InteractionType.CopyDish) },
+                    onCopyClick = { callbacks.setInteraction(InteractionType.CopyDish(
+                        context.getString(R.string.copy_dish_prefilled_name, state.editableName)
+                    )) },
                     onBackClick = { navController.popBackStack() }
                 )
             }
@@ -307,7 +310,7 @@ private fun EditDishScreenContent(
                                 )
                             }
 
-                            InteractionType.CopyDish -> {
+                            is InteractionType.CopyDish -> {
                                 ValueEditDialog(
                                     title = stringResource(R.string.copy_dish),
                                     value = editableCopiedDishName,

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.sharp.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.sharp.Delete
-import androidx.compose.material.icons.sharp.Face
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -36,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
@@ -140,6 +140,7 @@ fun DishDetailsScreen(
                     }
                 }
             }
+
             else -> {
                 navController.popBackStack()
             }
@@ -405,7 +406,7 @@ private fun EditDishTopBar(
                     },
                     leadingIcon = {
                         Icon(
-                            imageVector = Icons.Sharp.Face,
+                            painter = painterResource(R.drawable.content_copy_24dp),
                             contentDescription = stringResource(R.string.copy_dish)
                         )
                     }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.sharp.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.sharp.Delete
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -416,7 +415,7 @@ private fun EditDishTopBar(
                     },
                     leadingIcon = {
                         Icon(
-                            imageVector = Icons.Sharp.Delete,
+                            painter = painterResource(R.drawable.delete_24dp),
                             contentDescription = stringResource(R.string.remove_dish)
                         )
                     }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsViewModel.kt
@@ -25,6 +25,7 @@ import com.erdees.foodcostcalc.domain.model.product.UsedProductDomain
 import com.erdees.foodcostcalc.domain.usecase.CopyDishUseCase
 import com.erdees.foodcostcalc.ext.toShareableText
 import com.erdees.foodcostcalc.ui.navigation.FCCScreen.Companion.DISH_ID_KEY
+import com.erdees.foodcostcalc.ui.navigation.FCCScreen.Companion.IS_COPIED
 import com.erdees.foodcostcalc.ui.screens.recipe.RecipeHandler
 import com.erdees.foodcostcalc.ui.screens.recipe.RecipeUpdater
 import com.erdees.foodcostcalc.ui.screens.recipe.RecipeViewMode
@@ -52,6 +53,7 @@ import timber.log.Timber
  * Shared ViewModel between [DishDetailsScreen] and [RecipeScreen].
  * It was decided to share it in order to avoid passing data between screens.
  * */
+// TODO LAUNCH UNSAVED CHANGES DIALOG WHEN USER ATTEMPTS TO COPY DISH WITH UNSAVED CHANGES
 class DishDetailsViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel(),
     KoinComponent {
 
@@ -98,8 +100,23 @@ class DishDetailsViewModel(private val savedStateHandle: SavedStateHandle) : Vie
         updateStep = recipeHandler::updateStep
     )
 
+    private val _showCopyConfirmation = MutableStateFlow(false)
+    val showCopyConfirmation: StateFlow<Boolean> = _showCopyConfirmation
+
     init {
         fetchDish()
+        checkIfCopied()
+    }
+
+    private fun checkIfCopied() {
+        val isCopied = savedStateHandle.get<Boolean>(IS_COPIED) ?: false
+        if (isCopied) {
+            _showCopyConfirmation.value = true
+        }
+    }
+
+    fun hideCopyConfirmation() {
+        _showCopyConfirmation.value = false
     }
 
     private fun fetchDish() {

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsViewModel.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.erdees.foodcostcalc.R
 import com.erdees.foodcostcalc.data.Preferences
 import com.erdees.foodcostcalc.data.repository.AnalyticsRepository
 import com.erdees.foodcostcalc.data.repository.DishRepository
@@ -364,12 +363,12 @@ class DishDetailsViewModel(private val savedStateHandle: SavedStateHandle) : Vie
         }
     }
 
-    fun discardChangesAndProceed(context: Context) {
+    fun discardChangesAndProceed(getName: (String?) -> String) {
         // Restore dish to original state
         viewModelScope.launch {
             loadDishStateFromRepository()
             resetScreenState()
-            showCopyDish( context.getString(R.string.copy_dish_prefilled_name, dish.value?.name))
+            showCopyDish(getName(_dish.value?.name))
         }
     }
 
@@ -386,15 +385,13 @@ class DishDetailsViewModel(private val savedStateHandle: SavedStateHandle) : Vie
      * If there are unsaved changes, prompts the user to decide what to do first
      * Otherwise, proceeds directly to the copy dish dialog
      */
-    fun handleCopyDish(context: Context) {
+    fun handleCopyDish(getName: (String?) -> String) {
         if (hasUnsavedChanges()) {
             _screenState.update {
                 ScreenState.Interaction(InteractionType.UnsavedChangesConfirmationBeforeCopy)
             }
         } else {
-            showCopyDish(
-                context.getString(R.string.copy_dish_prefilled_name, dish.value?.name)
-            )
+            showCopyDish(getName(_dish.value?.name))
         }
     }
 

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsViewModel.kt
@@ -116,7 +116,7 @@ class DishDetailsViewModel(private val savedStateHandle: SavedStateHandle) : Vie
                         recipeHandler.updateRecipeViewMode(RecipeViewMode.EDIT)
                     }
                     _dish.update { this }
-                    // Store original dish for unsaved changes detection
+                    _editableName.update { this.name }
                     originalDish = this.copy()
                     recipeHandler.updateRecipe(this.recipe.toEditableRecipe())
                     originalProducts = this.products
@@ -189,7 +189,7 @@ class DishDetailsViewModel(private val savedStateHandle: SavedStateHandle) : Vie
             }
 
             is InteractionType.CopyDish ->
-                _editableCopiedDishName.value = dish.value?.name ?: ""
+                _editableCopiedDishName.value = interaction.prefilledName
 
             else -> {}
         }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/EditDishScreenStateProvider.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/EditDishScreenStateProvider.kt
@@ -41,7 +41,8 @@ class EditDishScreenStateProvider : PreviewParameterProvider<EditDishScreenState
             editableCopiedDishName = "",
             editableTotalPrice = "120",
             currency = sampleCurrency,
-            screenState = ScreenState.Idle // or ScreenState.Idle if you have one
+            screenState = ScreenState.Idle,
+            showCopyConfirmation = false
         ),
         // Loading State
         EditDishScreenState(
@@ -55,7 +56,8 @@ class EditDishScreenStateProvider : PreviewParameterProvider<EditDishScreenState
             editableCopiedDishName = "",
             editableTotalPrice = "",
             currency = sampleCurrency,
-            screenState = ScreenState.Loading<Nothing>()
+            screenState = ScreenState.Loading<Nothing>(),
+            showCopyConfirmation = false
         ),
         // Error State
         EditDishScreenState(
@@ -69,7 +71,8 @@ class EditDishScreenStateProvider : PreviewParameterProvider<EditDishScreenState
             editableCopiedDishName = "",
             editableTotalPrice = "",
             currency = sampleCurrency,
-            screenState = ScreenState.Error(Error("Something went wrong!"))
+            screenState = ScreenState.Error(Error("Something went wrong!")),
+            showCopyConfirmation = false
         ),
         // Interaction: Edit Name
         EditDishScreenState(
@@ -83,7 +86,8 @@ class EditDishScreenStateProvider : PreviewParameterProvider<EditDishScreenState
             editableCopiedDishName = "",
             editableTotalPrice = sampleDish.totalPrice.toString(),
             currency = sampleCurrency,
-            screenState = ScreenState.Interaction(InteractionType.EditName)
+            screenState = ScreenState.Interaction(InteractionType.EditName),
+            showCopyConfirmation = false
         ),
         // Interaction: Edit Tax
         EditDishScreenState(
@@ -97,7 +101,8 @@ class EditDishScreenStateProvider : PreviewParameterProvider<EditDishScreenState
             editableCopiedDishName = "",
             editableTotalPrice = sampleDish.totalPrice.toString(),
             currency = sampleCurrency,
-            screenState = ScreenState.Interaction(InteractionType.EditTax)
+            screenState = ScreenState.Interaction(InteractionType.EditTax),
+            showCopyConfirmation = false
         ),
     )
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/EditDishScreenStateProvider.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/EditDishScreenStateProvider.kt
@@ -38,6 +38,7 @@ class EditDishScreenStateProvider : PreviewParameterProvider<EditDishScreenState
             editableTax = "10",
             editableMargin = "150",
             editableName = sampleDish.name,
+            editableCopiedDishName = "",
             editableTotalPrice = "120",
             currency = sampleCurrency,
             screenState = ScreenState.Idle // or ScreenState.Idle if you have one
@@ -51,6 +52,7 @@ class EditDishScreenStateProvider : PreviewParameterProvider<EditDishScreenState
             editableTax = "",
             editableMargin = "",
             editableName = "",
+            editableCopiedDishName = "",
             editableTotalPrice = "",
             currency = sampleCurrency,
             screenState = ScreenState.Loading<Nothing>()
@@ -64,6 +66,7 @@ class EditDishScreenStateProvider : PreviewParameterProvider<EditDishScreenState
             editableTax = "",
             editableMargin = "",
             editableName = "",
+            editableCopiedDishName = "",
             editableTotalPrice = "",
             currency = sampleCurrency,
             screenState = ScreenState.Error(Error("Something went wrong!"))
@@ -77,6 +80,7 @@ class EditDishScreenStateProvider : PreviewParameterProvider<EditDishScreenState
             editableTax = "10",
             editableMargin = "150",
             editableName = sampleDish.name,
+            editableCopiedDishName = "",
             editableTotalPrice = sampleDish.totalPrice.toString(),
             currency = sampleCurrency,
             screenState = ScreenState.Interaction(InteractionType.EditName)
@@ -90,6 +94,7 @@ class EditDishScreenStateProvider : PreviewParameterProvider<EditDishScreenState
             editableTax = "10", // Current tax being edited
             editableMargin = "150",
             editableName = sampleDish.name,
+            editableCopiedDishName = "",
             editableTotalPrice = sampleDish.totalPrice.toString(),
             currency = sampleCurrency,
             screenState = ScreenState.Interaction(InteractionType.EditTax)

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/UsedItem.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/UsedItem.kt
@@ -1,0 +1,82 @@
+package com.erdees.foodcostcalc.ui.screens.dishes.editDish
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.sharp.Delete
+import androidx.compose.material.icons.sharp.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.erdees.foodcostcalc.domain.model.UsedItem
+
+@Composable
+fun UsedItem(
+    usedItem: UsedItem,
+    onRemove: (UsedItem) -> Unit,
+    onEdit: (UsedItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val swipeState = rememberSwipeToDismissBoxState()
+
+    SwipeToDismissBox(
+        modifier = modifier.animateContentSize(),
+        state = swipeState,
+        backgroundContent = {
+            Box(
+                contentAlignment = Alignment.CenterEnd,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = MaterialTheme.colorScheme.error)
+            ) {
+                Icon(
+                    modifier = Modifier.minimumInteractiveComponentSize(),
+                    imageVector = Icons.Sharp.Delete,
+                    contentDescription = null
+                )
+            }
+        },
+        enableDismissFromStartToEnd = false,
+        enableDismissFromEndToStart = true,
+        content = {
+            ListItem(
+                colors = (ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.background)),
+                headlineContent = {
+                    Text(text = usedItem.item.name)
+                },
+                supportingContent = {
+                    Text(text = usedItem.quantity.toString() + " " + usedItem.quantityUnit)
+                },
+                trailingContent = {
+                    IconButton(onClick = { onEdit(usedItem) }) {
+                        Icon(imageVector = Icons.Sharp.Edit, contentDescription = "Edit")
+                    }
+                })
+        })
+
+    when (swipeState.currentValue) {
+        SwipeToDismissBoxValue.EndToStart -> {
+            LaunchedEffect(swipeState) {
+                swipeState.reset()
+            }
+            onRemove(usedItem)
+        }
+
+        SwipeToDismissBoxValue.StartToEnd -> {}
+
+        SwipeToDismissBoxValue.Settled -> {}
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/UsedItem.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/UsedItem.kt
@@ -20,7 +20,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -55,6 +57,7 @@ fun UsedItem(
     onEdit: (UsedItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val currentOnRemove by rememberUpdatedState(onRemove)
     val density = LocalDensity.current
     val positionalThreshold = SwipeToDismissBoxDefaults.positionalThreshold
     val swipeState = remember(System.identityHashCode(usedItem)) {
@@ -68,9 +71,9 @@ fun UsedItem(
         )
     }
 
-    LaunchedEffect(swipeState.currentValue) {
+    LaunchedEffect(swipeState.currentValue, usedItem) {
         if (swipeState.currentValue == SwipeToDismissBoxValue.EndToStart) {
-            onRemove(usedItem)
+            currentOnRemove(usedItem)
         }
     }
 

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.sharp.ArrowBack
-import androidx.compose.material.icons.sharp.Delete
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -27,6 +26,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
@@ -208,9 +208,8 @@ private fun EditHalfProductTopBar(
         actions = {
             IconButton(onClick = onDeleteClick) {
                 Icon(
-                    imageVector = Icons.Sharp.Delete, contentDescription = stringResource(
-                        id = R.string.content_description_remove_half_product
-                    )
+                    painter = painterResource(R.drawable.delete_24dp),
+                    contentDescription = stringResource(id = R.string.content_description_remove_half_product)
                 )
             }
         },

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/products/editProduct/EditProductScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/products/editProduct/EditProductScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.sharp.ArrowBack
-import androidx.compose.material.icons.sharp.Delete
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -28,6 +27,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -137,7 +137,7 @@ private fun EditProductTopBar(
         actions = {
             IconButton(onClick = onDeleteClick) {
                 Icon(
-                    imageVector = Icons.Sharp.Delete,
+                    painter = painterResource(R.drawable.delete_24dp),
                     contentDescription = stringResource(id = R.string.content_description_remove_product)
                 )
             }

--- a/app/src/main/java/com/erdees/foodcostcalc/utils/Constants.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/utils/Constants.kt
@@ -81,6 +81,7 @@ object Constants {
         }
 
         object DishV2 {
+            const val COPY = "dish_copy"
             const val DELETE = "dish_delete_clicked"
             const val DELETED = "dish_deleted"
             const val PRODUCT_CREATED = "product_created_dishv2"

--- a/app/src/main/res/drawable/content_copy_24dp.xml
+++ b/app/src/main/res/drawable/content_copy_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M300,680v-560h440v560L300,680ZM340,640h360v-480L340,160v480ZM180,800v-535.38h40L220,760h375.38v40L180,800ZM340,640v-480,480Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/app/src/main/res/drawable/delete_24dp.xml
+++ b/app/src/main/res/drawable/delete_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M240,800v-560h-40v-40h160v-30.77h240L600,200h160v40h-40v560L240,800ZM280,760h400v-520L280,240v520ZM392.31,680h40v-360h-40v360ZM527.69,680h40v-360h-40v360ZM280,240v520,-520Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,9 @@
     <string name="add_product">Add Ingredient</string>
     <string name="add_half_product">Add Half Product</string>
     <string name="item_added">%1$s added</string>
+    <string name="copy">copy</string>
+    <string name="copy_dish">Copy Dish</string>
+    <string name="more_options">More Options</string>
 
     <!-- Delete confirmation dialog -->
     <string name="delete_item_title">Delete \'%1$s\'?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,7 @@
     <string name="item_added">%1$s added</string>
     <string name="copy">copy</string>
     <string name="copy_dish">Copy Dish</string>
+    <string name="copy_dish_prefilled_name">%1$s Copy</string>
     <string name="more_options">More Options</string>
 
     <!-- Delete confirmation dialog -->


### PR DESCRIPTION
Improve Dish Details Screen with Copy Functionality and UI Enhancements

This commit introduces several improvements to the Dish Details screen, including code refactoring, copy dish functionality, and UI enhancements.

**Key changes:**

*   **Code Refactoring:**
    *   Moved `DishDetails` and `UsedItem` composables to separate files (`DishDetails.kt` and `UsedItem.kt`) for better organization.
    *   Extracted screen state and interaction handling logic into `ScreenStateHandler` and `InteractionHandler` composables within `DishDetailsScreen.kt` to improve readability.
*   **Copy Dish Functionality:**
    *   Added "Copy Dish" option to the dish details screen menu.
    *   Implemented `CopyDishUseCase` to handle dish duplication (including products, half-products, and recipe).
    *   Updated `DishDetailsViewModel` to use `CopyDishUseCase` for copy operations.
    *   Introduced `DishDetailsActionResultType.COPIED` and `DishActionResult` to manage copy operation results and navigation.
    *   Prefills the copied dish name with "[original name] Copy".
    *   Added a confirmation pop-up after a successful copy.
    *   Added analytics event (`DishV2.COPY`) for dish copy action.
*   **Unsaved Changes Handling:**
    *   Implemented a check for unsaved changes before copying a dish.
    *   Displays an "Unsaved Changes" dialog, prompting the user to save or discard changes before copying.
*   **UI Enhancements and Bug Fixes:**
    *   Renamed `ConfirmAndNavigate` composable to `ConfirmPopUp` and generalized its `navigate` parameter to `actionAfter`.
    *   Replaced `Icons.Sharp.Delete` with `R.drawable.delete_24dp` for the delete icon in multiple screens.
    *   Fixed an issue in `UsedItem.kt` to ensure the `onRemove` callback uses the latest function version with `rememberUpdatedState`.
    *   Updated `UsedItem` composable to correctly reset its swipe state when an item is removed and restored.
*   **Other Changes:**
    *   Renamed `DishActionResultType` to `DishDetailsActionResultType` and added `UPDATED_STAY` type.
    *   Made `ProductAndProductDish.toUsedProductDomain()` and `ProductUsedInHalfProduct.toUsedProductDomain()` private.
    *   Added `UnsavedChangesConfirmationBeforeCopy` to `InteractionType`.