### PR TITLE
S.T.A.Y-Quick-Undo-Item-Delete

### DIFF
--- a/app/src/main/java/com/erdees/foodcostcalc/domain/model/JustRemovedItem.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/model/JustRemovedItem.kt
@@ -1,0 +1,9 @@
+package com.erdees.foodcostcalc.domain.model
+
+/**
+ * Represents an item that has been removed from dish or half product.
+ * */
+data class JustRemovedItem(
+    val item: UsedItem,
+    val index: Int
+)

--- a/app/src/main/java/com/erdees/foodcostcalc/ext/SnackbarHostState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ext/SnackbarHostState.kt
@@ -1,0 +1,24 @@
+package com.erdees.foodcostcalc.ext
+
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+
+suspend fun SnackbarHostState.showUndoDeleteSnackbar(
+    message: String,
+    actionLabel: String,
+    actionPerformed: () -> Unit,
+    ignored: () -> Unit = { }
+) {
+    val result = showSnackbar(
+        message = message,
+        actionLabel = actionLabel,
+        duration = SnackbarDuration.Short,
+        withDismissAction = true,
+    )
+    if (result == SnackbarResult.ActionPerformed) {
+        actionPerformed()
+    } else {
+        ignored()
+    }
+}

--- a/app/src/main/java/com/erdees/foodcostcalc/ext/SnackbarHostState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ext/SnackbarHostState.kt
@@ -14,7 +14,7 @@ suspend fun SnackbarHostState.showUndoDeleteSnackbar(
         message = message,
         actionLabel = actionLabel,
         duration = SnackbarDuration.Short,
-        withDismissAction = true,
+        withDismissAction = false,
     )
     if (result == SnackbarResult.ActionPerformed) {
         actionPerformed()

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -211,7 +212,6 @@ private fun EditDishScreenContent(
                 onBackClick = { navController.popBackStack() }
             )
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValues ->
         Box(modifier = Modifier.padding(paddingValues)) {
             Column {
@@ -236,24 +236,27 @@ private fun EditDishScreenContent(
                 }
 
                 Column(Modifier) {
-                    uiState.dish?.let {
-                        DishDetails(
-                            it,
-                            uiState.currency,
-                            onTaxClick = {
-                                actions.setInteraction(InteractionType.EditTax)
-                            },
-                            onMarginClick = {
-                                actions.setInteraction(InteractionType.EditMargin)
-                            },
-                            onTotalPriceClick = {
-                                actions.setInteraction(InteractionType.EditTotalPrice)
-                            }
-                        )
+                    Box(contentAlignment = Alignment.BottomCenter) {
+                        uiState.dish?.let {
+                            DishDetails(
+                                it,
+                                uiState.currency,
+                                onTaxClick = {
+                                    actions.setInteraction(InteractionType.EditTax)
+                                },
+                                onMarginClick = {
+                                    actions.setInteraction(InteractionType.EditMargin)
+                                },
+                                onTotalPriceClick = {
+                                    actions.setInteraction(InteractionType.EditTotalPrice)
+                                }
+                            )
+                        }
+                        SnackbarHost(snackbarHostState)
                     }
 
                     Buttons(
-                        modifier = Modifier.padding(top = 16.dp),
+                        modifier = Modifier.padding(top = 8.dp),
                         saveDish = { actions.saveDish() },
                         shareDish = { actions.shareDish(it) },
                         navigate = {

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
@@ -220,6 +220,7 @@ private fun EditDishScreenContent(
                         item::class.simpleName + item.id.toString()
                     }) { item ->
                         UsedItem(
+                            modifier = Modifier.animateItem(),
                             usedItem = item,
                             onRemove = { actions.removeItem(it) },
                             onEdit = {

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsScreen.kt
@@ -109,7 +109,7 @@ fun DishDetailsScreen(
     }
 
     LaunchedEffect(uiState.lastRemovedItem) {
-        val removedItem = uiState.lastRemovedItem ?: return@LaunchedEffect
+        val removedItem = uiState.lastRemovedItem?.item ?: return@LaunchedEffect
         snackbarHostState.showUndoDeleteSnackbar(
             message = context.getString(R.string.removed_item, removedItem.item.name),
             actionLabel = context.getString(R.string.undo),

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsUiState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsUiState.kt
@@ -1,6 +1,7 @@
 package com.erdees.foodcostcalc.ui.screens.dishes.editDish
 
 import android.icu.util.Currency
+import com.erdees.foodcostcalc.domain.model.JustRemovedItem
 import com.erdees.foodcostcalc.domain.model.ScreenState
 import com.erdees.foodcostcalc.domain.model.UsedItem
 import com.erdees.foodcostcalc.domain.model.dish.DishDomain
@@ -15,7 +16,7 @@ data class DishDetailsUiState(
     val showCopyConfirmation: Boolean = false,
     val currentlyEditedItem: UsedItem? = null,
     val currency: Currency? = null,
-    val lastRemovedItem: UsedItem? = null, // Added for undo feature
+    val lastRemovedItem: JustRemovedItem? = null,
 ){
     val items: List<UsedItem> = (dish?.products ?: listOf()) + (dish?.halfProducts ?: listOf())
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsUiState.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsUiState.kt
@@ -15,6 +15,7 @@ data class DishDetailsUiState(
     val showCopyConfirmation: Boolean = false,
     val currentlyEditedItem: UsedItem? = null,
     val currency: Currency? = null,
+    val lastRemovedItem: UsedItem? = null, // Added for undo feature
 ){
     val items: List<UsedItem> = (dish?.products ?: listOf()) + (dish?.halfProducts ?: listOf())
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishDetailsViewModel.kt
@@ -72,8 +72,8 @@ class DishDetailsViewModel(private val savedStateHandle: SavedStateHandle) : Vie
     private val interactionHandler = InteractionHandler()
     private val dishPropertySaver = DishPropertySaver()
     private val dishItemOperationHandler = DishItemOperationHandler(
-        updateUiState = { updatedDish ->
-            _uiState.update { it.copy(dish = updatedDish) }
+        updateUiState = { newState ->
+            _uiState.update { newState }
         }
     )
 
@@ -242,6 +242,18 @@ class DishDetailsViewModel(private val savedStateHandle: SavedStateHandle) : Vie
             item = item,
             uiState = _uiState.value
         )
+    }
+
+    /**
+     * Restores the last removed item to the dish and clears lastRemovedItem.
+     */
+    fun undoRemoveItem() {
+        val item = _uiState.value.lastRemovedItem ?: return
+        dishItemOperationHandler.restoreItem(item, _uiState.value)
+    }
+
+    fun clearLastRemovedItem() {
+        _uiState.update { it.copy(lastRemovedItem = null) }
     }
 
     /**

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishItemOperationHandler.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishItemOperationHandler.kt
@@ -1,5 +1,6 @@
 package com.erdees.foodcostcalc.ui.screens.dishes.editDish
 
+import com.erdees.foodcostcalc.domain.model.JustRemovedItem
 import com.erdees.foodcostcalc.domain.model.UsedItem
 import com.erdees.foodcostcalc.domain.model.halfProduct.UsedHalfProductDomain
 import com.erdees.foodcostcalc.domain.model.product.UsedProductDomain
@@ -73,21 +74,23 @@ class DishItemOperationHandler(
 
         when (item) {
             is UsedProductDomain -> {
+                val index = currentDish.products.indexOf(item)
                 val updatedProducts = currentDish.products.filter { it != item }
                 updateUiState(
                     uiState.copy(
                         dish = currentDish.copy(products = updatedProducts),
-                        lastRemovedItem = item
+                        lastRemovedItem = JustRemovedItem(item, index)
                     )
                 )
             }
 
             is UsedHalfProductDomain -> {
+                val index = currentDish.halfProducts.indexOf(item)
                 val updatedHalfProducts = currentDish.halfProducts.filter { it != item }
                 updateUiState(
                     uiState.copy(
                         dish = currentDish.copy(halfProducts = updatedHalfProducts),
-                        lastRemovedItem = item
+                        lastRemovedItem = JustRemovedItem(item, index)
                     )
                 )
             }
@@ -101,13 +104,14 @@ class DishItemOperationHandler(
      * @param uiState The current UI state of the dish details screen
      */
     fun restoreItem(
-        item: UsedItem,
+        item: JustRemovedItem,
         uiState: DishDetailsUiState
     ) {
         val currentDish = uiState.dish ?: return
-        when (item) {
+        when (item.item) {
             is UsedProductDomain -> {
-                val updatedProducts = currentDish.products.toMutableList().apply { add(item) }
+                val updatedProducts =
+                    currentDish.products.toMutableList().apply { add(item.index, item.item) }
                 updateUiState(
                     uiState.copy(
                         dish = currentDish.copy(products = updatedProducts),
@@ -118,7 +122,7 @@ class DishItemOperationHandler(
 
             is UsedHalfProductDomain -> {
                 val updatedHalfProducts =
-                    currentDish.halfProducts.toMutableList().apply { add(item) }
+                    currentDish.halfProducts.toMutableList().apply { add(item.index, item.item) }
                 updateUiState(
                     uiState.copy(
                         dish = currentDish.copy(halfProducts = updatedHalfProducts),

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishItemOperationHandler.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/editDish/DishItemOperationHandler.kt
@@ -1,13 +1,12 @@
 package com.erdees.foodcostcalc.ui.screens.dishes.editDish
 
 import com.erdees.foodcostcalc.domain.model.UsedItem
-import com.erdees.foodcostcalc.domain.model.dish.DishDomain
 import com.erdees.foodcostcalc.domain.model.halfProduct.UsedHalfProductDomain
 import com.erdees.foodcostcalc.domain.model.product.UsedProductDomain
 import timber.log.Timber
 
 class DishItemOperationHandler(
-    private val updateUiState: (DishDomain) -> Unit
+    private val updateUiState: (DishDetailsUiState) -> Unit
 ) {
 
     /**
@@ -32,7 +31,11 @@ class DishItemOperationHandler(
                     val updatedItem = currentlyEditedItem.copy(quantity = quantity)
                     val updatedProducts = currentDish.products.toMutableList()
                         .apply { set(index, updatedItem) }
-                    updateUiState(currentDish.copy(products = updatedProducts))
+                    updateUiState(
+                        uiState.copy(
+                            dish = currentDish.copy(products = updatedProducts)
+                        )
+                    )
                 }
             }
 
@@ -42,7 +45,11 @@ class DishItemOperationHandler(
                     val updatedItem = currentlyEditedItem.copy(quantity = quantity)
                     val updatedHalfProducts = currentDish.halfProducts.toMutableList()
                         .apply { set(index, updatedItem) }
-                    updateUiState(currentDish.copy(halfProducts = updatedHalfProducts))
+                    updateUiState(
+                        uiState.copy(
+                            dish = currentDish.copy(halfProducts = updatedHalfProducts)
+                        )
+                    )
                 }
             }
         }
@@ -67,12 +74,57 @@ class DishItemOperationHandler(
         when (item) {
             is UsedProductDomain -> {
                 val updatedProducts = currentDish.products.filter { it != item }
-                updateUiState(currentDish.copy(products = updatedProducts))
+                updateUiState(
+                    uiState.copy(
+                        dish = currentDish.copy(products = updatedProducts),
+                        lastRemovedItem = item
+                    )
+                )
             }
 
             is UsedHalfProductDomain -> {
                 val updatedHalfProducts = currentDish.halfProducts.filter { it != item }
-                updateUiState(currentDish.copy(halfProducts = updatedHalfProducts))
+                updateUiState(
+                    uiState.copy(
+                        dish = currentDish.copy(halfProducts = updatedHalfProducts),
+                        lastRemovedItem = item
+                    )
+                )
+            }
+        }
+    }
+
+    /**
+     * Restores a previously removed item to the dish.
+     *
+     * @param item The item to restore
+     * @param uiState The current UI state of the dish details screen
+     */
+    fun restoreItem(
+        item: UsedItem,
+        uiState: DishDetailsUiState
+    ) {
+        val currentDish = uiState.dish ?: return
+        when (item) {
+            is UsedProductDomain -> {
+                val updatedProducts = currentDish.products.toMutableList().apply { add(item) }
+                updateUiState(
+                    uiState.copy(
+                        dish = currentDish.copy(products = updatedProducts),
+                        lastRemovedItem = null
+                    )
+                )
+            }
+
+            is UsedHalfProductDomain -> {
+                val updatedHalfProducts =
+                    currentDish.halfProducts.toMutableList().apply { add(item) }
+                updateUiState(
+                    uiState.copy(
+                        dish = currentDish.copy(halfProducts = updatedHalfProducts),
+                        lastRemovedItem = null
+                    )
+                )
             }
         }
     }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductScreen.kt
@@ -181,6 +181,7 @@ private fun EditHalfProductScreenContent(
                 LazyColumn(Modifier.weight(fill = true, weight = 1f)) {
                     items(state.usedItems, key = { item -> item.id }) { item ->
                         UsedItem(
+                            modifier = Modifier.animateItem(),
                             usedItem = item,
                             onRemove = callbacks.removeItem,
                             onEdit = {

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Alignment.Companion.TopCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -171,7 +172,6 @@ private fun EditHalfProductScreenContent(
                 onNameClick = { callbacks.setInteraction(InteractionType.EditName) }
             )
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValues ->
         Box(
             modifier = Modifier.padding(paddingValues),
@@ -194,21 +194,26 @@ private fun EditHalfProductScreenContent(
                     }
                 }
 
-                state.halfProduct?.let {
-                    HalfProductDetails(
-                        halfProductDomain = it,
-                        currency = state.currency,
-                        modifier = Modifier
-                    )
-                }
-
-                ButtonRow(
-                    modifier = Modifier.padding(end = 12.dp),
-                    primaryButton = {
-                        FCCPrimaryButton(text = stringResource(id = R.string.save)) {
-                            callbacks.saveHalfProduct()
+                Box(contentAlignment = TopCenter) {
+                    Column {
+                        state.halfProduct?.let {
+                            HalfProductDetails(
+                                halfProductDomain = it,
+                                currency = state.currency,
+                                modifier = Modifier
+                            )
                         }
-                    })
+
+                        ButtonRow(
+                            modifier = Modifier.padding(end = 12.dp),
+                            primaryButton = {
+                                FCCPrimaryButton(text = stringResource(id = R.string.save)) {
+                                    callbacks.saveHalfProduct()
+                                }
+                            })
+                    }
+                    SnackbarHost(snackbarHostState)
+                }
             }
 
             HandleScreenState(state, callbacks, navController)

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -146,14 +147,20 @@ fun EditHalfProductScreen(
         saveAndNavigate = viewModel::saveAndNavigate
     )
 
-    EditHalfProductScreenContent(state = state, callbacks = callbacks, navController)
+    EditHalfProductScreenContent(
+        state = state,
+        callbacks = callbacks,
+        navController,
+        snackbarHostState
+    )
 }
 
 @Composable
 private fun EditHalfProductScreenContent(
     state: EditHalfProductScreenState,
     callbacks: EditHalfProductScreenCallbacks,
-    navController: NavController
+    navController: NavController,
+    snackbarHostState: SnackbarHostState,
 ) {
     Scaffold(
         topBar = {
@@ -163,7 +170,8 @@ private fun EditHalfProductScreenContent(
                 onDeleteClick = callbacks.onDeleteHalfProductClick,
                 onNameClick = { callbacks.setInteraction(InteractionType.EditName) }
             )
-        }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValues ->
         Box(
             modifier = Modifier.padding(paddingValues),

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductScreen.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductScreen.kt
@@ -94,7 +94,7 @@ fun EditHalfProductScreen(
     val editableQuantity by viewModel.editableQuantity.collectAsState()
     val editableName by viewModel.editableName.collectAsState()
     val currency by viewModel.currency.collectAsState()
-    val lastRemovedItem by viewModel.lastRemovedItem.collectAsState()
+    val lastRemovedItem by viewModel.justRemovedItem.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
 
     BackHandler {
@@ -102,7 +102,7 @@ fun EditHalfProductScreen(
     }
 
     LaunchedEffect(lastRemovedItem) {
-        val removedItem = lastRemovedItem ?: return@LaunchedEffect
+        val removedItem = lastRemovedItem?.item ?: return@LaunchedEffect
         snackbarHostState.showUndoDeleteSnackbar(
             message = context.getString(R.string.removed_item, removedItem.item.name),
             actionLabel = context.getString(R.string.undo),

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/halfProducts/editHalfProduct/EditHalfProductViewModel.kt
@@ -244,7 +244,7 @@ class EditHalfProductViewModel(private val savedStateHandle: SavedStateHandle) :
     }
 
     /**
-     * Restores the last removed item to the dish and clears lastRemovedItem.
+     * Restores the last removed item to the half-product and clears lastRemovedItem.
      */
     fun undoRemoveItem() {
         val item = lastRemovedItem.value as? UsedProductDomain ?: return

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
 
     <!-- COMMON -->
 
+    <string name="undo">Undo</string>
     <string name="description">Description</string>
 
     <string name="edit_quantity">Edit quantity</string>
@@ -153,6 +154,7 @@
     <string name="copy_dish">Copy Dish</string>
     <string name="copy_dish_prefilled_name">%1$s Copy</string>
     <string name="more_options">More Options</string>
+    <string name="removed_item">Removed %1$s</string>
 
     <!-- Delete confirmation dialog -->
     <string name="delete_item_title">Delete \'%1$s\'?</string>


### PR DESCRIPTION
Yolo coding, haven't even tested this

This commit introduces an "undo" functionality for removing items (products or half-products) from a dish or half-product.

When an item is removed:
- It's temporarily stored as `lastRemovedItem` in the UI state.
- A snackbar appears with an "Undo" action.
- Clicking "Undo" restores the item.
- If the snackbar is dismissed or times out, `lastRemovedItem` is cleared.

This applies to both the "Edit Dish" and "Edit Half-Product" screens.

Technical changes:
- Added `lastRemovedItem` to `DishDetailsUiState` and `EditHalfProductViewModel`.
- Implemented `undoRemoveItem()` and `clearLastRemovedItem()` methods in both `DishDetailsViewModel` and `EditHalfProductViewModel`.
- `DishItemOperationHandler` now updates the `lastRemovedItem` in `DishDetailsUiState` when an item is removed or restored.
- Added a `showUndoDeleteSnackbar` extension function for `SnackbarHostState` to standardize the undo snackbar behavior.
- Updated `DishDetailsScreen` and `EditHalfProductScreen` to display the undo snackbar and handle its actions.
- Added new string resources for "Undo" and "Removed item %1$s".