### PR TITLE
Refactor: Track dish count in analytics

### DIFF
--- a/app/src/main/java/com/erdees/foodcostcalc/data/db/dao/dish/DishDao.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/data/db/dao/dish/DishDao.kt
@@ -31,4 +31,7 @@ interface DishDao {
 
     @Query("UPDATE dishes SET recipeId=:recipeId WHERE dishId=:dishId ")
     suspend fun update(recipeId: Long, dishId: Long)
+
+    @Query("SELECT COUNT(*) FROM dishes")
+    suspend fun getDishCount(): Int
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/data/repository/AnalyicsRepository.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/data/repository/AnalyicsRepository.kt
@@ -17,6 +17,9 @@ import timber.log.Timber
  * @see AnalyticsRepositoryImpl for the implementation details.
  */
 interface AnalyticsRepository {
+
+    fun setUserProperty(name: String, value: String?)
+
     fun logEvent(event: String)
 
     fun logEvent(event: String, bundle: Bundle?)
@@ -26,6 +29,15 @@ interface AnalyticsRepository {
 
 class AnalyticsRepositoryImpl(private val firebaseAnalytics: FirebaseAnalytics) :
     AnalyticsRepository {
+
+    override fun setUserProperty(name: String, value: String?) {
+        if (!BuildConfig.DEBUG) {
+            firebaseAnalytics.setUserProperty(name, value)
+        } else {
+            Timber.d("Set user property: $name = $value")
+        }
+    }
+
     override fun logEvent(event: String) {
         this.logEvent(event, null)
     }

--- a/app/src/main/java/com/erdees/foodcostcalc/data/repository/DishRepository.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/data/repository/DishRepository.kt
@@ -15,6 +15,8 @@ interface DishRepository {
     val dishes: Flow<List<CompleteDish>>
     suspend fun getDish(id: Long): Flow<CompleteDish>
 
+    suspend fun getDishCount(): Int
+
     suspend fun addDish(dish: DishBase) : Long
     suspend fun deleteDish(dishId: Long)
     suspend fun updateDish(dish: DishBase)
@@ -34,6 +36,9 @@ class DishRepositoryImpl : DishRepository, KoinComponent {
     override val dishes: Flow<List<CompleteDish>> = dishDao.getCompleteDishes()
 
     override suspend fun getDish(id: Long) = dishDao.getCompleteDish(id)
+
+    override suspend fun getDishCount(): Int = dishDao.getDishCount()
+
 
     override suspend fun addDish(dish: DishBase): Long = dishDao.addDish(dish)
 

--- a/app/src/main/java/com/erdees/foodcostcalc/domain/usecase/DeleteDishUseCase.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/domain/usecase/DeleteDishUseCase.kt
@@ -20,7 +20,7 @@ class DeleteDishUseCase(
         withContext(myDispatchers.ioDispatcher) {
             try {
                 dishRepository.deleteDish(dishId)
-                logDishDeletionEvent()
+                logDishDeletionEvent(dishRepository.getDishCount())
 
                 Result.success(
                     DishActionResult(
@@ -33,7 +33,11 @@ class DeleteDishUseCase(
             }
         }
 
-    private fun logDishDeletionEvent() {
+    private fun logDishDeletionEvent(dishCount: Int) {
         analyticsRepository.logEvent(Constants.Analytics.DishV2.DELETED, null)
+        analyticsRepository.setUserProperty(
+            Constants.Analytics.UserProperties.DISH_COUNT,
+            dishCount.toString()
+        )
     }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/FCCActivity.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/FCCActivity.kt
@@ -5,11 +5,22 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
+import com.erdees.foodcostcalc.data.repository.AnalyticsRepository
+import com.erdees.foodcostcalc.data.repository.DishRepository
 import com.erdees.foodcostcalc.ui.screens.hostScreen.FCCHostScreen
 import com.erdees.foodcostcalc.ui.theme.FCCTheme
+import com.erdees.foodcostcalc.utils.Constants
+import com.erdees.foodcostcalc.utils.MyDispatchers
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 import timber.log.Timber
 
 class FCCActivity : AppCompatActivity() {
+
+    private val dishRepository: DishRepository by inject()
+    private val analyticsRepository: AnalyticsRepository by inject()
+    private val dispatches: MyDispatchers by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -21,6 +32,22 @@ class FCCActivity : AppCompatActivity() {
             FCCTheme {
                 FCCHostScreen()
             }
+        }
+
+        lifecycleScope.launch(dispatches.ioDispatcher) {
+            updateDishCountUserProperty()
+        }
+    }
+
+    private suspend fun updateDishCountUserProperty() {
+        try {
+            val dishCount = dishRepository.getDishCount()
+            analyticsRepository.setUserProperty(
+                Constants.Analytics.UserProperties.DISH_COUNT,
+                dishCount.toString()
+            )
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to update dish count user property")
         }
     }
 }

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/CreateDishV2ViewModel.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/CreateDishV2ViewModel.kt
@@ -397,7 +397,11 @@ class CreateDishV2ViewModel : FCCBaseViewModel(), KoinComponent {
 
                 _isLoading.update { false }
                 _saveDishSuccess.update { dishId }
-                analyticsHelper.logDishSaveSuccess(dishName.value, addedProducts.value.size)
+                analyticsHelper.logDishSaveSuccess(
+                    dishName.value,
+                    addedProducts.value.size,
+                    dishRepository.getDishCount()
+                )
             } catch (e: Exception) {
                 analyticsHelper.logDishSaveFailureAnalytics(dishName.value)
                 handleError(e)

--- a/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/DishCreationAnalyticsHelper.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/ui/screens/dishes/createDishV2/DishCreationAnalyticsHelper.kt
@@ -78,7 +78,7 @@ class DishCreationAnalyticsHelper(val analyticsRepository: AnalyticsRepository) 
             })
     }
 
-    fun logDishSaveSuccess(dishName: String, addedProductsSize: Int) {
+    fun logDishSaveSuccess(dishName: String, addedProductsSize: Int, dishCount: Int) {
         analyticsRepository.logEvent(
             Constants.Analytics.DishV2.DISH_SAVE_SUCCESS,
             Bundle().apply {
@@ -91,6 +91,7 @@ class DishCreationAnalyticsHelper(val analyticsRepository: AnalyticsRepository) 
         analyticsRepository.logEvent(Constants.Analytics.DISH_CREATED, Bundle().apply {
             putString(Constants.Analytics.DISH_NAME, dishName)
         })
+        analyticsRepository.setUserProperty(Constants.Analytics.UserProperties.DISH_COUNT, dishCount.toString())
     }
 
     fun logDishSaveAttempt(

--- a/app/src/main/java/com/erdees/foodcostcalc/utils/Constants.kt
+++ b/app/src/main/java/com/erdees/foodcostcalc/utils/Constants.kt
@@ -16,6 +16,11 @@ object Constants {
     }
 
     object Analytics {
+
+        object UserProperties {
+            const val DISH_COUNT = "dish_count"
+        }
+
         const val DISH_CREATED = "dish_created"
         const val HALF_PRODUCT_CREATED = "half_product_created"
         const val PRODUCT_CREATED = "product_created"


### PR DESCRIPTION
This commit introduces analytics tracking for the number of dishes.

- A new user property `dish_count` is added to Firebase Analytics.
- The `dish_count` property is updated when:
    - A new dish is created.
    - A dish is deleted.
    - The application starts (`FCCActivity`).
- The `AnalyticsRepository` is extended to support setting user properties.
- The `DishRepository` and `DishDao` are updated to provide the total dish count.