### PR TITLE
Update UML diagrams with MeasurementUnit type

### DIFF
--- a/design/data/database/new.plantuml
+++ b/design/data/database/new.plantuml
@@ -8,7 +8,7 @@ entity "ProductBase" as p {
     *pricePerUnit : number
     *tax : number
     *waste : number
-    *unit : text
+    *unit : MeasurementUnit
     --
     <<computed>>
     +priceAfterWasteAndTax : number
@@ -19,7 +19,7 @@ entity "HalfProductBase" as hp {
     *halfProductId : number <<generated>>
     --
     *name : text
-    *halfProductUnit : text
+    *halfProductUnit : MeasurementUnit
 }
 
 entity "DishBase" as d {
@@ -55,7 +55,7 @@ entity "ProductDish" as pd {
     *productId : number <<FK>>
     *dishId : number <<FK>>
     *quantity : number
-    *quantityUnit : text
+    *quantityUnit : MeasurementUnit
 }
 
 entity "ProductHalfProduct" as php {
@@ -64,7 +64,7 @@ entity "ProductHalfProduct" as php {
     *productId : number <<FK>>
     *halfProductId : number <<FK>>
     *quantity : number
-    *quantityUnit : text
+    *quantityUnit : MeasurementUnit
     *weightPiece : number?
     --
     <<computed>>
@@ -77,7 +77,7 @@ entity "HalfProductDish" as hpd {
     *halfProductId : number <<FK>>
     *dishId : number <<FK>>
     *quantity : number
-    *quantityUnit : text
+    *quantityUnit : MeasurementUnit
 }
 
 ' Remote/Local sync entities
@@ -165,5 +165,6 @@ note top of cd : Main view for complete dish\nwith all ingredients and recipe
 note right of chp : Half product with all\nits constituent products
 note bottom of php : Supports weight per piece\nfor items sold by count
 note left of fre : Local cache of remote\nfeature requests
+note top of p : Uses UnitConverters for\nMeasurementUnit serialization
 
 @enduml

--- a/design/data/domain/models.plantuml
+++ b/design/data/domain/models.plantuml
@@ -12,7 +12,7 @@ interface AdItem {
 interface ItemUsageEntry {
     +item : Item
     +quantity : Double
-    +quantityUnit : String
+    +quantityUnit : MeasurementUnit
     +foodCost : Double
     +formattedTotalPricePerServing(amountOfServings: Double, currency: Currency?) : String
     +formatQuantityForTargetServing(servings: Double) : String
@@ -31,7 +31,7 @@ entity ProductDomain {
     +pricePerUnit : Double
     +tax : Double
     +waste : Double
-    +unit : String
+    +unit : MeasurementUnit
     --
     -priceWithTax : Double
     +priceAfterWasteAndTax : Double
@@ -43,13 +43,13 @@ entity EditableProductDomain {
     +pricePerUnit : String
     +tax : String
     +waste : String
-    +unit : String
+    +unit : MeasurementUnit
 }
 
 entity HalfProductDomain {
     +id : Long
     +name : String
-    +halfProductUnit : String
+    +halfProductUnit : MeasurementUnit
     +products : List<UsedProductDomain>
     --
     -singleRecipePrice : Double
@@ -84,14 +84,14 @@ entity DishDomain {
 entity ProductAddedToDish {
     +item : ProductDomain
     +quantity : Double
-    +quantityUnit : String
+    +quantityUnit : MeasurementUnit
     +foodCost : Double
 }
 
 entity HalfProductAddedToDish {
     +item : HalfProductDomain
     +quantity : Double
-    +quantityUnit : String
+    +quantityUnit : MeasurementUnit
     +foodCost : Double
 }
 
@@ -101,7 +101,7 @@ entity UsedProductDomain {
     +ownerId : Long
     +item : ProductDomain
     +quantity : Double
-    +quantityUnit : String
+    +quantityUnit : MeasurementUnit
     +weightPiece : Double?
     +foodCost : Double
     --
@@ -113,7 +113,7 @@ entity UsedHalfProductDomain {
     +ownerId : Long
     +item : HalfProductDomain
     +quantity : Double
-    +quantityUnit : String
+    +quantityUnit : MeasurementUnit
     +foodCost : Double
 }
 


### PR DESCRIPTION
The `unit` and `quantityUnit` fields in various entities have been updated from `text` or `String` to the `MeasurementUnit` type in both database and domain model diagrams.

This change provides better type safety and clarity regarding the units used for product quantities and measurements. A note has also been added to the database diagram indicating the use of `UnitConverters` for `MeasurementUnit` serialization in the `Product` entity.